### PR TITLE
fix(ci): add required permissions to release-please workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}


### PR DESCRIPTION
## Summary
- Fixes 403 "Resource not accessible by integration" errors in release-please workflow
- Adds explicit `contents: write` and `pull-requests: write` permissions to the job

## Problem
The release-please workflow was failing with permission errors when trying to create branches and pull requests. The default `GITHUB_TOKEN` has restricted permissions that require explicit declaration.

## Solution
Added a `permissions` block to the `release-please` job with the required scopes:
- `contents: write` - Allows creating git refs/branches  
- `pull-requests: write` - Allows creating and managing pull requests

## Test plan
- [ ] Merge this PR to main branch
- [ ] Verify release-please workflow runs successfully on next push
- [ ] Confirm it can create release PR without permission errors

🤖 Generated with [Claude Code](https://claude.ai/code)