### PR TITLE
fix(ci): run cuenv tasks within nix develop environment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,10 +33,11 @@ jobs:
       - name: Magic Nix Cache
         uses: DeterminateSystems/magic-nix-cache-action@v2
 
-      - name: Build cuenv and run CI
-        run: |
-          nix build .#cuenv
-          ./result/bin/cuenv task ci
+      - name: Build cuenv
+        run: nix build .#cuenv
+
+      - name: Run CI checks
+        run: nix develop --command ./result/bin/cuenv task ci
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
@@ -57,10 +58,11 @@ jobs:
       - name: Magic Nix Cache
         uses: DeterminateSystems/magic-nix-cache-action@v2
 
-      - name: Build cuenv and run CI
-        run: |
-          nix build .#cuenv
-          ./result/bin/cuenv task ci
+      - name: Build cuenv
+        run: nix build .#cuenv
+
+      - name: Run CI checks
+        run: nix develop --command ./result/bin/cuenv task ci
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
@@ -83,7 +85,8 @@ jobs:
       - name: Magic Nix Cache
         uses: DeterminateSystems/magic-nix-cache-action@v2
 
-      - name: Build cuenv and run release
-        run: |
-          nix build .#cuenv
-          ./result/bin/cuenv task release
+      - name: Build cuenv
+        run: nix build .#cuenv
+
+      - name: Run release task
+        run: nix develop --command ./result/bin/cuenv task release

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,6 +6,12 @@ on:
   release:
     types: [published]
   workflow_dispatch:
+
+# Required for Magic Nix Cache to authenticate with GitHub's cache API
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   website:
     runs-on: ubuntu-latest
@@ -16,19 +22,14 @@ jobs:
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v19
 
-      - name: Build cuenv
-        run: |
-          nix build .#cuenv
-          mkdir -p bin
-          cp -L result/bin/cuenv bin/cuenv
+      - name: Magic Nix Cache
+        uses: DeterminateSystems/magic-nix-cache-action@v2
 
-      - name: Setup cuenv
-        run: |
-          chmod +x bin/cuenv
-          echo "$(pwd)/bin" >> $GITHUB_PATH
+      - name: Build cuenv
+        run: nix build .#cuenv
 
       - name: Build docs
-        run: cuenv task docs.build
+        run: nix develop --command ./result/bin/cuenv task docs.build
         env:
           CI: "true"
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,18 +8,22 @@ env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
 
+# Required for Magic Nix Cache to authenticate with GitHub's cache API
+permissions:
+  contents: write
+  id-token: write
+
 jobs:
   publish-cue:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@v16
-        with:
-          extra_nix_config: |
-            accept-flake-config = true
-            experimental-features = nix-command flakes
+        uses: DeterminateSystems/nix-installer-action@v19
+
+      - name: Magic Nix Cache
+        uses: DeterminateSystems/magic-nix-cache-action@v2
 
       - name: Publish CUE module
         run: nix develop --accept-flake-config --command cue mod publish ${{ github.event.release.tag_name }}
@@ -46,18 +50,14 @@ jobs:
             archive: zip
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install Nix (Unix)
-        uses: DeterminateSystems/nix-installer-action@v16
-        with:
-          extra_nix_config: |
-            accept-flake-config = true
-            experimental-features = nix-command flakes
+        uses: DeterminateSystems/nix-installer-action@v19
         if: matrix.os != 'windows-latest'
 
-      - name: Install devenv (Unix)
-        run: nix profile install --accept-flake-config nixpkgs#devenv
+      - name: Magic Nix Cache (Unix)
+        uses: DeterminateSystems/magic-nix-cache-action@v2
         if: matrix.os != 'windows-latest'
 
       - name: Install Rust (Windows)
@@ -70,25 +70,12 @@ jobs:
           go-version: "1.24"
         if: matrix.os == 'windows-latest'
 
-      - name: Build development environment (Unix)
-        run: nix develop --accept-flake-config --command echo "Development environment ready"
-        if: matrix.os != 'windows-latest'
-
       - name: Build cuenv (Unix)
-        run: |
-          nix build .#cuenv
-          mkdir -p bin
-          cp -L result/bin/cuenv bin/cuenv
-        if: matrix.os != 'windows-latest'
-
-      - name: Setup cuenv (Unix)
-        run: |
-          chmod +x bin/cuenv
-          echo "$(pwd)/bin" >> $GITHUB_PATH
+        run: nix build .#cuenv
         if: matrix.os != 'windows-latest'
 
       - name: Build release (Unix)
-        run: cuenv task release.build
+        run: nix develop --command ./result/bin/cuenv task release.build
         if: matrix.os != 'windows-latest'
 
       - name: Build release (Windows)
@@ -122,7 +109,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-release-artifacts]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Download all artifacts
         uses: actions/download-artifact@v4
@@ -147,7 +134,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: upload-release-assets
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Update Homebrew Formula
         env:


### PR DESCRIPTION
The cuenv task runner requires development tools (treefmt, cargo-nextest,
cargo-audit, cargo-deny, cargo-llvm-cov, bun, etc.) that are only available
in the devShell, not in the bare nix build output.

Changes:
- Run `nix develop --command ./result/bin/cuenv task ...` instead of directly
  executing the cuenv binary outside the dev environment
- Add Magic Nix Cache to deploy and release workflows for faster builds
- Add required permissions for cache authentication
- Upgrade actions/checkout to v5 and nix-installer-action to v19 for consistency
- Simplify release workflow by removing unnecessary devenv installation steps