### PR TITLE
feat: add script field for inline shell scripts in tasks

### DIFF
--- a/schema/tasks.cue
+++ b/schema/tasks.cue
@@ -11,7 +11,27 @@ package schema
 
 #Task: {
 	shell?: #Shell
-	command!: string
+
+	// Command to execute. Required unless 'script' is provided.
+	command?: string
+
+	// Inline script to execute (alternative to command).
+	// When script is provided, shell defaults to bash if not specified.
+	// Supports multiline strings and shebang lines for polyglot scripts.
+	// Example:
+	//   script: """
+	//       #!/bin/bash
+	//       set -euo pipefail
+	//       echo "Building..."
+	//       cargo build --release
+	//       """
+	script?: string
+
+	// Validation: exactly one of command or script must be provided
+	_hasCommand: command != _|_
+	_hasScript:  script != _|_
+	_validTask:  true & ((_hasCommand & !_hasScript) | (!_hasCommand & _hasScript))
+
 	args?: [...string]
 	env?: [string]: #EnvironmentVariable
 


### PR DESCRIPTION
Add a 'script' field as an alternative to 'command' in task definitions, enabling multiline shell scripts with CUE's heredoc syntax.

Changes:
- schema/tasks.cue: Add script field with validation (exactly one of command or script required)
- Task struct: Add script field with custom Deserialize to properly handle untagged enum deserialization for TaskDefinition
- Executor: Handle script execution with default bash shell

Example usage:
  tasks: { deploy: { script: """ #!/bin/bash set -euo pipefail cargo build --release ./scripts/deploy.sh """ } }

Also includes:
- Fix clippy warning in env.rs (collapsible if)
- Formatting updates from treefmt