### PR TITLE
fix: add static linking flags for Go CGO bridge on musl

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -98,10 +98,10 @@
 
             mkdir -p $out/debug $out/release
 
-            go build -buildmode=c-archive -o $out/debug/libcue_bridge.a bridge.go
+            go build -buildmode=c-archive -ldflags="${pkgs.lib.optionalString pkgs.stdenv.targetPlatform.isMusl "-linkmode external -extldflags '-static'"}" -o $out/debug/libcue_bridge.a bridge.go
             cp libcue_bridge.h $out/debug/
-            
-            CGO_ENABLED=1 go build -ldflags="-s -w" -buildmode=c-archive -o $out/release/libcue_bridge.a bridge.go
+
+            CGO_ENABLED=1 go build -ldflags="-s -w${pkgs.lib.optionalString pkgs.stdenv.targetPlatform.isMusl " -linkmode external -extldflags '-static'"}" -buildmode=c-archive -o $out/release/libcue_bridge.a bridge.go
             cp libcue_bridge.h $out/release/
             
             runHook postBuild


### PR DESCRIPTION
Fixes #161

This PR fixes the static build issue for musl targets by adding proper linker flags to the Go CGO bridge build.

### Changes

- Added `-linkmode external -extldflags '-static'` to Go build commands for musl targets
- Ensures the Go CGO archive is fully static with no dynamic libc dependencies
- Applied conditionally only for musl builds, other platforms unaffected

Generated with [Claude Code](https://claude.ai/code)