### PR TITLE
feat: move CODEOWNERS and ignore to #Base for layered configuration

### DIFF
--- a/crates/core/src/manifest/mod.rs
+++ b/crates/core/src/manifest/mod.rs
@@ -168,6 +168,14 @@ pub struct Base {
     /// Workspaces configuration
     #[serde(skip_serializing_if = "Option::is_none")]
     pub workspaces: Option<HashMap<String, WorkspaceConfig>>,
+
+    /// Code ownership configuration
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub owners: Option<Owners>,
+
+    /// Ignore patterns for tool-specific ignore files
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ignore: Option<Ignore>,
 }
 
 /// Ignore patterns for tool-specific ignore files.

--- a/schema/core.cue
+++ b/schema/core.cue
@@ -28,6 +28,8 @@ package schema
 	config?:     #Config
 	env?:        #Env
 	workspaces?: #Workspaces
+	owners?:     #Owners
+	ignore?:     #Ignore
 })
 
 #ProjectName: string & =~"^[a-zA-Z0-9._-]+$"
@@ -38,9 +40,7 @@ package schema
 	hooks?:   #Hooks
 	ci?:      #CI
 	release?: #Release
-	owners?:  #Owners
 	tasks?: [string]: #Tasks
-	ignore?: #Ignore
 	cube?:   #Cube
 })
 


### PR DESCRIPTION
### **User description**
## Summary

This PR implements layered CODEOWNERS and ignore file support by moving these fields from `#Project` to `#Base`.

## Changes

- Move `owners` and `ignore` fields from `#Project` to `#Base` in CUE schema
- Update Rust `Base` struct to include these fields
- Enables directory-by-directory configuration with paths keyed from each #Base location

## Related

Fixes #200

---

Generated with [Claude Code](https://claude.ai/code)) | [View job run](https://github.com/cuenv/cuenv/actions/runs/20251538611) | [Branch](https://github.com/cuenv/cuenv/tree/claude/issue-200-20251215-2355


___

### **PR Type**
Enhancement


___

### **Description**
- Move `owners` and `ignore` fields from `#Project` to `#Base` in CUE schema

- Enable layered CODEOWNERS and ignore file configuration per directory

- Update Rust `Base` struct to include `owners` and `ignore` fields

- Support directory-by-directory configuration with correct path resolution


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["#Base schema"] -->|"add owners, ignore"| B["Layered configuration"]
  C["#Project schema"] -->|"remove owners, ignore"| B
  D["Rust Base struct"] -->|"add owners, ignore fields"| E["Updated manifest"]
  B --> E
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>core.cue</strong><dd><code>Move ownership and ignore config to Base schema</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

schema/core.cue

<ul><li>Add <code>owners?</code> and <code>ignore?</code> fields to <code>#Base</code> definition<br> <li> Remove <code>owners?</code> and <code>ignore?</code> fields from <code>#Project</code> definition<br> <li> <code>#Project</code> now inherits these fields from <code>#Base</code> via embedding</ul>


</details>


  </td>
  <td><a href="https://github.com/cuenv/cuenv/pull/201/files#diff-b3ffb52157d7b76b331b25fb7dcd2ff06696681429ae6f1bb641d384895eb75f">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Add owners and ignore fields to Base struct</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/core/src/manifest/mod.rs

<ul><li>Add <code>owners: Option<Owners></code> field to <code>Base</code> struct with serde skip_serializing_if<br> <li> Add <code>ignore: Option<Ignore></code> field to <code>Base</code> struct with serde skip_serializing_if<br> <li> Include documentation comments for both new fields</ul>


</details>


  </td>
  <td><a href="https://github.com/cuenv/cuenv/pull/201/files#diff-4e133777a0e812f8db6ad24fc09e4b9f10248f00d09f78f70d4674060edd1351">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

