### PR TITLE
Add diff output for cube sync

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -873,6 +873,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "similar",
  "tempfile",
  "thiserror 2.0.17",
  "tokio",
@@ -4662,6 +4663,12 @@ name = "simd-adler32"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+
+[[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "simple_asn1"

--- a/crates/cuenv/Cargo.toml
+++ b/crates/cuenv/Cargo.toml
@@ -69,6 +69,7 @@ sha2 = { workspace = true }
 walkdir = "2.5"
 dirs = { workspace = true }
 ctrlc = "3.4"
+similar = "2.6"
 
 [dev-dependencies]
 tempfile = { workspace = true }


### PR DESCRIPTION
### **User description**
## Summary
- add diff mode for cube sync output
- use similar to emit unified diffs

## Testing
- cargo check -p cuenv


___

### **PR Type**
Enhancement


___

### **Description**
- Implement diff output mode for cube sync command

- Add unified diff formatting for file mismatches

- Pass diff flag through sync function call chain

- Add `similar` crate dependency for diff generation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["execute_sync_cubes"] -->|"pass diff flag"| B["execute_sync_cubes_local"]
  B -->|"pass diff flag"| C["sync_cube_files"]
  C -->|"check/diff mode"| D["maybe_push_diff"]
  D -->|"format diffs"| E["format_unified_diff"]
  E -->|"TextDiff"| F["unified_diff output"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sync.rs</strong><dd><code>Implement diff output for cube sync operations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/cuenv/src/commands/sync.rs

<ul><li>Import <code>TextDiff</code> from <code>similar</code> crate for diff generation<br> <li> Remove TODO comment and implement diff parameter handling<br> <li> Thread <code>diff</code> parameter through function call chain: <code>execute_sync_cubes</code> <br>→ <code>execute_sync_cubes_local</code> → <code>sync_cube_files</code><br> <li> Add <code>maybe_push_diff</code> helper function to conditionally generate diffs <br>when files are out of sync or missing<br> <li> Add <code>format_unified_diff</code> function to generate unified diff format with <br>file headers<br> <li> Extend check mode logic to also trigger diff output when <code>diff</code> flag is <br>enabled</ul>


</details>


  </td>
  <td><a href="https://github.com/cuenv/cuenv/pull/205/files#diff-402277a5a53b43c9dc1f3d4a82575c39c01ab3441ec0da21e554128b68073d41">+56/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Cargo.toml</strong><dd><code>Add similar crate dependency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/cuenv/Cargo.toml

- Add `similar = "2.6"` dependency for unified diff generation


</details>


  </td>
  <td><a href="https://github.com/cuenv/cuenv/pull/205/files#diff-863b965f6436b0f4c177de5ba42f0f25259bebd7a962d960a15c2c3a5ad2edc5">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

