### PR TITLE
Populate CI task report metadata

### DIFF
--- a/crates/ci/src/affected.rs
+++ b/crates/ci/src/affected.rs
@@ -73,6 +73,25 @@ pub fn compute_affected_tasks(
         .collect()
 }
 
+#[must_use]
+pub fn matched_inputs_for_task(
+    task_name: &str,
+    config: &Project,
+    changed_files: &[PathBuf],
+    project_root: &Path,
+) -> Vec<String> {
+    let Some(task_def) = config.tasks.get(task_name) else {
+        return Vec::new();
+    };
+    let Some(task) = task_def.as_single() else {
+        return Vec::new();
+    };
+    task.iter_path_inputs()
+        .filter(|input_glob| matches_any(changed_files, project_root, input_glob))
+        .cloned()
+        .collect()
+}
+
 fn is_task_directly_affected(
     task_name: &str,
     config: &Project,


### PR DESCRIPTION
### **User description**
## Summary
- fill CI task report fields (inputs matched, outputs, cache key)
- reuse cache lookup for successful tasks

## Testing
- cargo check -p cuenv-ci


___

### **PR Type**
Enhancement


___

### **Description**
- Add `matched_inputs_for_task` function to compute matched inputs for tasks

- Populate CI task report with inputs_matched, outputs, and cache_key fields

- Reuse cache lookup for successful tasks to avoid redundant operations

- Replace TODO placeholders with actual metadata collection logic


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Task Execution"] --> B["Collect Matched Inputs"]
  A --> C["Extract Task Outputs"]
  A --> D["Lookup Cache Key"]
  B --> E["TaskReport"]
  C --> E
  D --> E
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>affected.rs</strong><dd><code>Add matched inputs computation function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/ci/src/affected.rs

<ul><li>Add new <code>matched_inputs_for_task</code> function to compute matched inputs for <br>a given task<br> <li> Function filters task path inputs against changed files<br> <li> Returns vector of matched input glob patterns<br> <li> Includes early returns for missing task definitions</ul>


</details>


  </td>
  <td><a href="https://github.com/cuenv/cuenv/pull/207/files#diff-5ea66d7add7965862816a59d5d94f15417557f4dd1b69a490ef28885f407aeac">+19/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>executor.rs</strong><dd><code>Populate task report metadata during execution</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/ci/src/executor.rs

<ul><li>Import <code>matched_inputs_for_task</code> from affected module and <code>task_cache</code> <br>from core<br> <li> Compute matched inputs for each task before execution<br> <li> Extract task outputs from task definition<br> <li> Lookup cache key for successful tasks using cache module<br> <li> Replace TODO placeholders with actual metadata values in TaskReport</ul>


</details>


  </td>
  <td><a href="https://github.com/cuenv/cuenv/pull/207/files#diff-65b2bccc6af3df3341e1c747ff1a22a31dd562736229f77fa2e201d326274e05">+21/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

