### PR TITLE
Use typed config for approvals

### DIFF
--- a/crates/cuenv/src/commands/exec.rs
+++ b/crates/cuenv/src/commands/exec.rs
@@ -124,15 +124,12 @@ pub async fn execute_exec(
     let directory = std::fs::canonicalize(path).unwrap_or_else(|_| Path::new(path).to_path_buf());
 
     // Check approval status before running hooks
-    let config_value = serde_json::to_value(&manifest).map_err(|e| {
-        cuenv_core::Error::configuration(format!("Failed to serialize config: {e}"))
-    })?;
-    let summary = ConfigSummary::from_json(&config_value);
+    let summary = ConfigSummary::from_project(&manifest);
 
     let hooks_approved = if summary.has_hooks {
         let mut approval_manager = ApprovalManager::with_default_file()?;
         approval_manager.load_approvals().await?;
-        let approval_status = check_approval_status(&approval_manager, &directory, &config_value)?;
+        let approval_status = check_approval_status(&approval_manager, &directory, &manifest)?;
         matches!(approval_status, ApprovalStatus::Approved)
     } else {
         true // No hooks = nothing to approve


### PR DESCRIPTION
### **User description**
## Summary
- replace JSON conversions with typed Project for approval hashing/summary
- normalize hook hashing via sorted hook maps

## Testing
- cargo check -p cuenv


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Replace JSON serialization with typed `Project` struct for approval hashing

- Normalize hook hashing via sorted `BTreeMap` for consistent ordering

- Simplify `ConfigSummary` logic using typed config instead of JSON parsing

- Update all approval-related functions to accept `Project` instead of `Value`

- Refactor tests to use typed config builders instead of JSON macros


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["JSON Value Config"] -->|"Replace with"| B["Typed Project Struct"]
  B -->|"Normalize hooks"| C["BTreeMap sorted hooks"]
  C -->|"Compute hash"| D["Approval Hash"]
  B -->|"Extract summary"| E["ConfigSummary"]
  F["Approval Functions"] -->|"Accept Project"| B
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>approval.rs</strong><dd><code>Migrate approval system from JSON to typed config</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/core/src/hooks/approval.rs

<ul><li>Replace <code>serde_json::Value</code> parameter with typed <code>Project</code> struct in <br><code>check_approval_status()</code> and <code>compute_approval_hash()</code><br> <li> Add <code>ApprovalHashInput</code> and <code>HooksForHash</code> structs with <code>BTreeMap</code> for <br>deterministic hook ordering<br> <li> Implement <code>sorted_hooks_map()</code> function to normalize hook maps before <br>hashing<br> <li> Rename <code>ConfigSummary::from_json()</code> to <code>from_project()</code> and rewrite logic <br>to work with typed config<br> <li> Simplify hook/env/task counting by directly accessing typed struct <br>fields instead of JSON parsing<br> <li> Refactor all tests to use <code>base_project()</code>, <code>make_hook()</code>, and <code>make_task()</code> <br>builders instead of <code>json!()</code> macros</ul>


</details>


  </td>
  <td><a href="https://github.com/cuenv/cuenv/pull/208/files#diff-d581163c4cf2542f9be1323a36681327321c48b8f653911908fe689e309791be">+188/-104</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>exec.rs</strong><dd><code>Use typed manifest for approval checks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/cuenv/src/commands/exec.rs

<ul><li>Remove <code>serde_json::to_value()</code> serialization of manifest<br> <li> Pass <code>&manifest</code> directly to <code>ConfigSummary::from_project()</code> instead of <br>serialized value<br> <li> Pass <code>&manifest</code> directly to <code>check_approval_status()</code> instead of <br>serialized value</ul>


</details>


  </td>
  <td><a href="https://github.com/cuenv/cuenv/pull/208/files#diff-97ea4f08dde1b558f91a5ef747455cae4dd032916d7c8aa267eac583553001bd">+2/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>export.rs</strong><dd><code>Eliminate JSON serialization in export command</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/cuenv/src/commands/export.rs

<ul><li>Remove <code>serde_json::to_value()</code> conversion of config<br> <li> Pass <code>&config</code> directly to <code>check_approval_status()</code> and <br><code>compute_approval_hash()</code><br> <li> Update <code>ConfigSummary::from_project()</code> call to use typed config</ul>


</details>


  </td>
  <td><a href="https://github.com/cuenv/cuenv/pull/208/files#diff-03c01a874c8feaca41087ef96476038db49b84f23183a71b6b5f7458fbaa71b0">+3/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>hooks.rs</strong><dd><code>Remove JSON conversion from hooks commands</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/cuenv/src/commands/hooks.rs

<ul><li>Remove <code>evaluate_config_as_value()</code> helper function that serialized to <br>JSON<br> <li> Update <code>get_config_hash()</code> to call <code>evaluate_config()</code> directly and pass <br>typed config to <code>compute_approval_hash()</code><br> <li> Remove <code>serde_json::to_value()</code> calls in <code>execute_env_load()</code> and <br><code>execute_allow()</code><br> <li> Update all <code>ConfigSummary::from_json()</code> calls to <code>from_project()</code></ul>


</details>


  </td>
  <td><a href="https://github.com/cuenv/cuenv/pull/208/files#diff-42b26e31ca0342f552b19c9c67ca7af4ad81c703175a45a819a7470c3f753c92">+8/-26</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

