### PR TITLE
chore(release): prepare release 0.17.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1506,7 +1506,7 @@ dependencies = [
 
 [[package]]
 name = "cuengine"
-version = "0.16.1"
+version = "0.17.0"
 dependencies = [
  "cc",
  "criterion",
@@ -1527,7 +1527,7 @@ dependencies = [
 
 [[package]]
 name = "cuenv"
-version = "0.16.1"
+version = "0.17.0"
 dependencies = [
  "assert_cmd",
  "async-trait",
@@ -1577,7 +1577,7 @@ dependencies = [
 
 [[package]]
 name = "cuenv-1password"
-version = "0.16.1"
+version = "0.17.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1596,7 +1596,7 @@ dependencies = [
 
 [[package]]
 name = "cuenv-aws"
-version = "0.16.1"
+version = "0.17.0"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -1612,7 +1612,7 @@ dependencies = [
 
 [[package]]
 name = "cuenv-bitbucket"
-version = "0.16.1"
+version = "0.17.0"
 dependencies = [
  "cuenv-codeowners",
  "cuenv-core",
@@ -1622,7 +1622,7 @@ dependencies = [
 
 [[package]]
 name = "cuenv-buildkite"
-version = "0.16.1"
+version = "0.17.0"
 dependencies = [
  "async-trait",
  "cuenv-ci",
@@ -1638,7 +1638,7 @@ dependencies = [
 
 [[package]]
 name = "cuenv-ci"
-version = "0.16.1"
+version = "0.17.0"
 dependencies = [
  "async-trait",
  "backoff",
@@ -1669,7 +1669,7 @@ dependencies = [
 
 [[package]]
 name = "cuenv-codeowners"
-version = "0.16.1"
+version = "0.17.0"
 dependencies = [
  "cuenv-core",
  "schemars 1.1.0",
@@ -1679,7 +1679,7 @@ dependencies = [
 
 [[package]]
 name = "cuenv-core"
-version = "0.16.1"
+version = "0.17.0"
 dependencies = [
  "async-recursion",
  "async-trait",
@@ -1716,7 +1716,7 @@ dependencies = [
 
 [[package]]
 name = "cuenv-cubes"
-version = "0.16.1"
+version = "0.17.0"
 dependencies = [
  "clap",
  "cuengine",
@@ -1737,7 +1737,7 @@ dependencies = [
 
 [[package]]
 name = "cuenv-dagger"
-version = "0.16.1"
+version = "0.17.0"
 dependencies = [
  "async-trait",
  "cuenv-core",
@@ -1748,7 +1748,7 @@ dependencies = [
 
 [[package]]
 name = "cuenv-events"
-version = "0.16.1"
+version = "0.17.0"
 dependencies = [
  "chrono",
  "serde",
@@ -1761,7 +1761,7 @@ dependencies = [
 
 [[package]]
 name = "cuenv-gcp"
-version = "0.16.1"
+version = "0.17.0"
 dependencies = [
  "async-trait",
  "cuenv-secrets",
@@ -1777,7 +1777,7 @@ dependencies = [
 
 [[package]]
 name = "cuenv-github"
-version = "0.16.1"
+version = "0.17.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1796,7 +1796,7 @@ dependencies = [
 
 [[package]]
 name = "cuenv-gitlab"
-version = "0.16.1"
+version = "0.17.0"
 dependencies = [
  "cuenv-codeowners",
  "cuenv-core",
@@ -1806,7 +1806,7 @@ dependencies = [
 
 [[package]]
 name = "cuenv-homebrew"
-version = "0.16.1"
+version = "0.17.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -1818,7 +1818,7 @@ dependencies = [
 
 [[package]]
 name = "cuenv-ignore"
-version = "0.16.1"
+version = "0.17.0"
 dependencies = [
  "gix",
  "serde",
@@ -1829,7 +1829,7 @@ dependencies = [
 
 [[package]]
 name = "cuenv-release"
-version = "0.16.1"
+version = "0.17.0"
 dependencies = [
  "chrono",
  "cuenv-core",
@@ -1857,7 +1857,7 @@ dependencies = [
 
 [[package]]
 name = "cuenv-secrets"
-version = "0.16.1"
+version = "0.17.0"
 dependencies = [
  "async-trait",
  "futures",
@@ -1876,7 +1876,7 @@ dependencies = [
 
 [[package]]
 name = "cuenv-vault"
-version = "0.16.1"
+version = "0.17.0"
 dependencies = [
  "async-trait",
  "cuenv-secrets",
@@ -1890,7 +1890,7 @@ dependencies = [
 
 [[package]]
 name = "cuenv-workspaces"
-version = "0.16.1"
+version = "0.17.0"
 dependencies = [
  "cargo-lock",
  "cargo_toml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,28 +39,28 @@ keywords = ["cue", "configuration", "validation", "ffi"]
 categories = ["config", "development-tools", "parsing"]
 
 [workspace.dependencies]
-cuenv-events = { path = "crates/events", version = "0.16.0" }
-cuenv-secrets = { path = "crates/secrets", version = "0.16.0" }
-cuenv-core = { path = "crates/core", version = "0.16.0" }
-cuenv-dagger = { path = "crates/dagger", version = "0.16.0" }
-cuenv-workspaces = { path = "crates/workspaces", version = "0.16.0" }
-cuenv-ci = { path = "crates/ci", version = "0.16.0" }
-cuenv-release = { path = "crates/release", version = "0.16.0" }
-cuenv-ignore = { path = "crates/ignore", version = "0.16.0" }
-cuenv-codeowners = { path = "crates/codeowners", version = "0.16.0" }
-cuenv-cubes = { path = "crates/cubes", version = "0.16.0" }
-cuengine = { path = "crates/cuengine", version = "0.16.0" }
+cuenv-events = { path = "crates/events", version = "0.17.0" }
+cuenv-secrets = { path = "crates/secrets", version = "0.17.0" }
+cuenv-core = { path = "crates/core", version = "0.17.0" }
+cuenv-dagger = { path = "crates/dagger", version = "0.17.0" }
+cuenv-workspaces = { path = "crates/workspaces", version = "0.17.0" }
+cuenv-ci = { path = "crates/ci", version = "0.17.0" }
+cuenv-release = { path = "crates/release", version = "0.17.0" }
+cuenv-ignore = { path = "crates/ignore", version = "0.17.0" }
+cuenv-codeowners = { path = "crates/codeowners", version = "0.17.0" }
+cuenv-cubes = { path = "crates/cubes", version = "0.17.0" }
+cuengine = { path = "crates/cuengine", version = "0.17.0" }
 # Platform-specific provider crates
-cuenv-github = { path = "crates/github", version = "0.16.0" }
-cuenv-gitlab = { path = "crates/gitlab", version = "0.16.0" }
-cuenv-bitbucket = { path = "crates/bitbucket", version = "0.16.0" }
-cuenv-buildkite = { path = "crates/buildkite", version = "0.16.0" }
-cuenv-homebrew = { path = "crates/homebrew", version = "0.16.0" }
+cuenv-github = { path = "crates/github", version = "0.17.0" }
+cuenv-gitlab = { path = "crates/gitlab", version = "0.17.0" }
+cuenv-bitbucket = { path = "crates/bitbucket", version = "0.17.0" }
+cuenv-buildkite = { path = "crates/buildkite", version = "0.17.0" }
+cuenv-homebrew = { path = "crates/homebrew", version = "0.17.0" }
 # Secret provider crates
-cuenv-aws = { path = "crates/aws", version = "0.16.0" }
-cuenv-gcp = { path = "crates/gcp", version = "0.16.0" }
-cuenv-vault = { path = "crates/vault", version = "0.16.0" }
-cuenv-1password = { path = "crates/1password", version = "0.16.0" }
+cuenv-aws = { path = "crates/aws", version = "0.17.0" }
+cuenv-gcp = { path = "crates/gcp", version = "0.17.0" }
+cuenv-vault = { path = "crates/vault", version = "0.17.0" }
+cuenv-1password = { path = "crates/1password", version = "0.17.0" }
 schemars = "1.0.4"
 thiserror = "2.0"
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
### **User description**
## Summary

| Package | Current | New | Bump |
|---------|---------|-----|------|
| cuenv-github | 0.16.1 | 0.17.0 | minor |
| cuenv-ci | 0.16.1 | 0.17.0 | minor |
| cuenv-homebrew | 0.16.1 | 0.17.0 | minor |
| cuenv-aws | 0.16.1 | 0.17.0 | minor |
| cuengine | 0.16.1 | 0.17.0 | minor |
| cuenv-buildkite | 0.16.1 | 0.17.0 | minor |
| cuenv-1password | 0.16.1 | 0.17.0 | minor |
| cuenv-gitlab | 0.16.1 | 0.17.0 | minor |
| cuenv-workspaces | 0.16.1 | 0.17.0 | minor |
| cuenv-release | 0.16.1 | 0.17.0 | minor |
| cuenv-codeowners | 0.16.1 | 0.17.0 | minor |
| cuenv | 0.16.1 | 0.17.0 | minor |
| cuenv-dagger | 0.16.1 | 0.17.0 | minor |
| cuenv-secrets | 0.16.1 | 0.17.0 | minor |
| cuenv-ignore | 0.16.1 | 0.17.0 | minor |
| cuenv-bitbucket | 0.16.1 | 0.17.0 | minor |
| cuenv-vault | 0.16.1 | 0.17.0 | minor |
| cuenv-events | 0.16.1 | 0.17.0 | minor |
| cuenv-core | 0.16.1 | 0.17.0 | minor |
| cuenv-cubes | 0.16.1 | 0.17.0 | minor |
| cuenv-gcp | 0.16.1 | 0.17.0 | minor |

## Commits

### Features

- **release**: add unified release prepare command with per-package versioning
- **release**: add release orchestration and Homebrew backend
- **tasks**: allow task groups as dependencies
- **ci**: implement stage-based provider injection architecture
- **ci**: auto-inject 1Password WASM setup step in GitHub workflows
- **secrets**: use OnePasswordResolver batch resolution for op:// refs
- **secrets**: resolve 1Password op:// references at runtime
- **ci**: auto-inject OP_SERVICE_ACCOUNT_TOKEN for 1Password secrets
- **ci**: add environment field to pipelines for secret resolution
- **ci**: add --check flag and sync-check workflow for workflow validation
- **secrets**: add batch resolution with secure memory handling
- **secrets**: add 1Password WASM SDK integration via cuenv secrets setup
- **secrets**: add auto-negotiating dual-mode secret resolvers
- **ci**: add monorepo-ready workflow naming with project prefix
- **ci**: add comprehensive trigger configuration and workflow generation
- **runtime**: add unified runtime model for project and task execution
- **ci**: add per-provider configuration support
- **github**: add workflow file generation with --format github
- **buildkite**: inject Nix bootstrap for tasks with runtime
- **buildkite**: wrap emitted commands with cuenv task
- **ci**: implement IR v1.3 schema and compiler foundation (#212)
- **exec**: warn when hooks not run due to missing approval
- **info**: add module-wide CUE evaluation command
- **owners**: change rules from array to map for CUE layering support
- add gitignore support for cube files and update dependencies
- **vscode**: add auto-completion for dependsOn and task references
- **codegen**: initial implementation of cuenv-codegen (#186)
- implement rich TUI with visual DAG and split-screen task output (#185)
- add code owner support with CODEOWNERS sync (#181)
- add ignorefile support via cuenv sync (#180)
- rich task source metadata and proximity-based listing (#176)
- switch to cargo-zigbuild for Linux releases, optimize CI
- **tasks**: add inputs/outputs to auto-injected install tasks
- dogfood cuenv ci with nix flake check delegation
- add script field for inline shell scripts in tasks (#109)
- add idempotency check for changeset generation in CI
- replace release-plz with native cuenv release management
- **ci**: add crates.io publishing with OIDC
- **ci**: support local changes against references with --from
- vscode extension
- add initial VSCode extension
- add json output for tasks and env list for IDE support
- add dynamic shell completions and global environment flag
- add support for task arguments (positional and named)
- dagger backend support working
- implement structured event system for multi-UI support
- implement ci workflow generation and replace schema-check
- implement cuenv ci command with native reporting
- add inputsFrom for hermetic task output chaining
- devenv schema for hooks
- **versioning**: unify workspace versioning and prepare 0.4.0 release
- **ci**: add concurrency control to cancel superseded runs
- environment selector for tasks and commands
- support controlling of nested hooks
- add CUE module registry support
- Add Factory GitHub workflows (#79)
- implement default task modality
- log command execution for cached tasks
- improve task execution logging
- implement workspaces and dependency resolution
- homebrew tap automation (#73)
- add environment variable access policies (#44)
- implement background hooks with approval mechanism and BDD testing (#35)
- cloudflare deployment
- implement background hook execution system with approval-based security (#31)
- Add task execution with DAG support using petgraph (#19)
- Add validated PackageDir and PackageName newtypes for API hygiene
- add bridge version diagnostics functionality
- add cuenv env print command with CUE package evaluation
- implement event-driven CLI with comprehensive test coverage
- add comprehensive CI/CD pipeline with trusted publishing
- add C header files and Go bridge tests
- implement Go-Rust FFI bridge for CUE evaluation
- implement cuenv-core with error handling and configuration
- set up Cargo workspace structure

### Bug Fixes

- **release**: use fixed versioning and treat breaking changes as minor in pre-1.0
- resolve clippy uninlined_format_args lint errors
- **release**: canonicalize root path to fix package detection in release prepare
- fast path eval for export (keep shells quick)
- sync github workflows
- couple of minor build/release issues
- **1password**: include secret reference in error messages
- **ci**: gh-models contributor only for pipelines with gh models tasks
- **ci**: resolve three failing workflows on main
- **cli**: show actual errors instead of misleading "No CI configuration found"
- **ci**: enable fixed-point iteration for stage contributors
- ensure release runs on production environment
- kill cargo-audit until nix version is updated
- regen github workflows
- inject cuenv build into ci
- flake caching, hopefully
- correct licneses for aws openssl
- **env**: resolve secrets in env print and fix clippy warnings
- **secrets**: implement 1Password WASM SDK host functions correctly
- **secrets**: use memory_new for WASM and add debug output
- **secrets**: implement 1Password WASM SDK host functions
- **ci**: use unique keys in proptest for env order invariance
- **exec**: redact secret values from command output
- **secrets**: use typed Secret resolver instead of string detection
- resolve all clippy warnings in cuenv-ci crate
- continue resolving clippy warnings
- resolve clippy warnings and code quality issues
- **clippy**: removing more clippy issues
- **buildkite**: improve changed files detection for shallow clones
- **buildkite**: install nix and build cuenv before generating pipeline
- **buildkite**: build cuenv before generating dynamic pipeline
- **ci**: ignore test_custom_shell in sandboxed builds
- **cuengine**: fix race condition in parallel CUE evaluation
- remove hidden fields
- **cuengine**: unquote CUE selector strings for proper JSON keys
- **cubes**: fix test_basic_cube_cue for Nix sandbox environment
- **info**: use CUE schema unification for project detection
- tidy up agents
- update example and tests for cubes package refactor
- update tests to use _examples package name
- address clippy warnings
- release vscode extension with cuenv
- hide examples package from cue publish
- improve performance of starship prompt (#189)
- work around cargo publishing being flakey
- move past partial cargo workspace publish
- default to ease union selection
- still schema fighting
- split task and command to avoid incomplete confusions
- schema was incorrect, needed more embedding
- close taskcommon too
- avoiding incomplete values with close on key types
- build llms.txt issue
- ignore local caches and validate project names
- task discover wasn't picking up taskmatchers properly
- task discovery from cue mod root
- dont rely on previous release artifacts
- schema inconsistencies for tasks and taskgroups
- cue schema for tasks
- dependencies on task groups now supported
- run all release pipeline tasks unconditionally
- include llms.txt and env.cue in nix build source
- dag bug for group tasks / added llmx.txt evals
- rust action name
- clippy linting
- treefmt
- ensure we exit non-zero for individual tgask failures
- remove awful CUEnv accident
- disable macos temporarily
- use setup-cuenv
- adopt zigbuild, remove musl
- graceful shallow clone handling for CI, optimize workflow
- actually run static in CI for confirmation
- attempting to fix static build
- hopefully static and go play nice
- documentation link to cuenv.dev
- id-token permission to release workflow
- attempting to fix static builds once and for all
- **nix**: skip tests for static musl builds
- bump to 0.10.1
- **ci**: remove temporary version_summary.txt file from release PRs
- **nix**: add binutils for Linux builds of libcue-bridge
- **ci**: error when pipeline not found instead of silently doing nothing
- **ci**: fail fast when running outside cue.mod directory
- treefmt
- read me badges (#100)
- **nix**: improve Crane source filtering for proper build caching
- git needed for build
- linting, builds, and json flags for release
- bugs
- improve error handling in manifest and release modules
- resolve clippy warnings in release management code
- address all PR review feedback
- ci improvements
- auth with crates properly and cut  0.8.6
- build static binaries
- vscode extension publish with bun compatibility
- ensure devenv/nix don't propagate to nested directories, likely unintended behaviour
- address PR review feedback
- handle negative numbers in task argument parsing
- handle Ctrl-C signal to prevent terminal escape sequence garbage
- hook syntax
- close onepasswordref
- build error with old crate name
- **core**: print dagger task output when capture_output is false
- **core**: suppress dagger-sdk logs using Config::default()
- **core**: suppress dagger-sdk logs using DAGGER_LOG_FORMAT=json
- release with token version bump
- added cue registry token
- checkout main branch in release-plz-release job to avoid detached HEAD
- sync cargo lock
- remove windows build, blocking release
- support dispatch runs for release with tag
- homebrew tap
- correct event bus test to match actual behavior
- ignore cross-project validation tests while hermetic execution disabled
- properly await renderer handle before exit
- address PR review comments and CI failures
- temporarily disable heremetic execution
- don't be over zealous with walking files
- **task**: prevent double printing of logs and improve caching output
- **cli**: flush stderr on error and remove redundant error logging
- log printing for task execution
- work on docs
- deploy correctly
- calculate affected jobs more consistently with prefixes
- address PR review comments and failing CI tests
- configure sccache in all CI jobs
- better error handling
- lint/format
- ci robustness and code quality improvements
- filter modules with pipelines
- stop using cuenv for cuenv build
- more ci fixes
- ensure docs can be deployed by fixing lock file
- **ci**: upgrade sccache-action to v0.0.9 to resolve coverage job failures
- **ci**: update release-plz to trigger on version tags without v-prefix
- **release**: prepare repository for release
- update release-plz workflow to use nix build for Go bridge
- **ci**: add id-token permission for Magic Nix Cache
- **approval**: hash only hooks for security approval
- **schema**: add cue.mod to task inputs for CUE validation
- **ci**: resolve disk space exhaustion on Ubuntu runners
- update hook definitions to use new map schema format
- schema for secrets
- continued ci fixes
- more ci fixes
- ensure agent knows how to work
- ci failures in test-suite and coverage
- ensure tests run correctly
- more ci fixes
- working on ci
- run hooks even during cached
- foreground hooks for ci
- task help subcommands (#78)
- conflict markers
- correct cuenv syntax for ci
- add task inputs for hermetic execution and resolve clippy warnings (#76)
- rename repository and fix schema issues
- preparinmg to publish
- robust hook execution and environment capture
- use delimiter for robust env capture from hooks
- make hook environment extraction resilient to errors and garbage
- support multiline exports in hooks and ensure exec waits for completion
- adding better tracing and logging for workspace support
- more ci fixes for lint etc
- resolve release blockers, schema drift, and test failures
- preparing workspaces feature for merge
- bump versions with env detector fixes
- cuenv env detection
- ensure workflows are consistent
- fmt and lint corrections
- align CUE schemas with Rust types for validation
- make Linux-specific tools conditional in flake.nix
- website deployment
- ensure deploy has node:
- treefmt
- include CUE files in flake source filter
- apply cargo fmt to pass flake checks
- resolve circular dependency between cuenv-core and cuengine (#33)
- **ci**: migrate to googleapis/release-please-action@v4 (#24)
- **ci**: add required permissions to release-please workflow
- macOS tests and remove header checkss
- format
- resolve clippy collapsible-if warnings
- resolve build and CI issues
- ensure codecov is available / treefmt
- **windows**: produce libcue_bridge.lib on MSVC and detect prebuilt .lib; keep legacy_stdio_definitions; retry windows-latest CI
- **windows**: link legacy_stdio_definitions to satisfy fprintf from Go c-archive; attempt to unbreak windows-latest CI
- resolve clippy warnings by using is_ascii_* methods
- **lint**: resolve uninlined_format_args clippy warnings
- **lint**: resolve clippy warnings and improve code quality
- resolve clippy warnings across the codebase
- increase test timeout to prevent CI failures
- remove broken tests that depend on runtime context
- ensure codecov will use token
- simplify CI to only run on Ubuntu and disable Go tests
- remove Windows runner and enable CGO for Go tests
- resolve CI failures by fixing formatting and clippy warnings
- address PR feedback and resolve clippy warnings
- resolve CI failures by fixing formatting and clippy warnings
- address PR feedback and resolve clippy warnings
- change cuengine license to MIT only and add license.md
- address Rust Edition 2024 compatibility and CI improvements
- use explicit versions in Cargo.toml for release-please compatibility

### Other Changes

- 0.16.1
- **sync**: introduce provider-based architecture with SyncMode enum
- sync ci workflows
- **cli**: move CI workflow generation to `cuenv sync ci`
- **commands**: reduce mod.rs from 2,050 to 535 lines
- **task**: add TaskExecutionRequest structured API
- **task**: extract normalization, resolution, and workspace modules
- **task**: split task.rs into modular directory structure
- 0.16.0
- add warning about rapid API/schema iteration
- **secrets**: extract providers into separate crates
- update documentation for 0.16.0 release (#215)
- complete CLEANUP.md - remove unwrap/expect, add functional patterns
- apply Rust coding standards from CLEANUP.md
- mark internal crates as non-publishable
- add temporary debug output for 1Password resolver
- debugging
- use typed #OnePasswordRef for production secrets
- **secrets**: add tests for EnvValue resolution including op:// refs
- **deps**: migrate from OpenSSL to rustls for TLS
- migrate CI/CD variables to 1Password
- fix formatting issues
- add formatter options, although basic for now, to task output
- **cuengine**: optimize CUE evaluation with parallel and targeted modes
- pass CommandExecutor through hook evaluation chain
- **cli**: wire up CommandExecutor event-driven architecture
- **cuengine**: unify CUE evaluation through evaluate_module
- **sync**: simplify CODEOWNERS sync output
- **owners**: remove defaultOwners in favor of catch-all rules
- 0.15.7
- cleanup and refactoring
- move owners/ignore to Base schema and fix sync -A performance
- update security isolation status in readme
- **vscode**: update to use --all flag for workspace tasks
- rename --workspace to --all on task command
- 0.15.6
- minor updates
- 0.15.5
- refactoring VCS provider into crates and strippping CUE tests from mod publish
- improve cubes docs to make it clear it's codegen with a funny name
- 0.15.4
- add cubes, and update ignore/owners
- 0.15.3
- move code file types to separate cubes package
- adopt cuenv ignores and owners
- replace .unwrap() with .expect() in production code
- use platform-appropriate paths via dirs crate
- fix cargo fmt
- 0.15.0
- separate sync/async command paths for faster CLI startup
- make cuenv crates useful as standalone libraries (#182)
- 0.14.1
- 0.14.0
- add comprehensive DAG builder tests for cross-project and hooks (#179)
- 0.13.0
- close more defs
- 0.12.5
- fmt
- 0.12.2
- overhaul
- make the examples tests
- generators are really just taskmatchers
- 0.12.0
- 0.11.7
- 0.11.5
- 0.11.2
- 0.11.1
- switch to Blacksmith runners for GitHub Actions
- use setup-cuenv action in release-pr workflow
- use pre-built cuenv binary for CI orchestration
- use pre-built binary for release-pr workflow
- 0.10.3
- migrate from magic-nix-cache to Cachix
- 0.10.1
- release (#155)
- remove droid
- extract git helper functions in tests
- add coverage for execute_changeset_from_commits with since_tag
- address code review style suggestions
- improve package path handling and version validation
- rename internal crate directories
- release v0.8.4
- 0.8.5
- 0.8.4
- bunch of cleanups
- migrate vscode-extension to bun
- 0.8.3
- add task parameters documentation
- dagger backend
- 0.8.2
- 0.8.1
- 0.8.0
- release v0.7.1
- rename cuenv-cli to cuenv
- enable dagger-backend feature by default
- update dagger example to enable dagger backend by default
- add examples/dagger-task to demonstrate Dagger backend
- **core**: implement TaskBackend trait and Dagger integration
- externalInputs merged into inputs for cleaner API
- release v0.7.1
- release v0.6.1
- release v0.6.1
- release v0.6.0
- **workspaces**: optimize glob resolution using walkdir
- update documentation to reflect current API and architecture
- update installation instructions to prefer Nix Flake
- **cuenv-ci**: release v0.6.0
- consolidate workflows into a single cross-platform job using cuenv ci
- migrate to cuenv ci pipelines and optimize workflows
- add cuenv ci pipeline job to test context-aware execution
- use cuenv for ci/release tasks
- add devenv hook schema
- huge refresdh on latest changes
- overhaul documentation website and guides
- **ci**: migrate from release-please to release-plz
- **ci**: de-duplicate nix-checks and build-cuenv
- remove Go vendoring in favor of Nix vendorHash
- upgrade CUE from v0.8.2 to v0.15.0
- release v0.3.1
- Release v0.3.0
- add CUE module publishing to release workflow
- dogfood cuenv for developer tasks and CI workflows
- release (#45)
- remove flakehub
- **deps**: bump cc from 1.2.39 to 1.2.40 (#51)
- **deps**: bump petgraph from 0.8.2 to 0.8.3 (#49)
- **deps**: bump actions/checkout from 4 to 5 (#47)
- bump to v0.1.1
- rfcs and adrs
- deploy on main
- add flake to cuenv
- **deps**: bump uuid from 1.18.0 to 1.18.1
- **deps**: bump clap from 4.5.45 to 4.5.47
- **deps**: bump cc from 1.2.34 to 1.2.36
- **deps**: bump actions/cache from 3 to 4
- **deps**: bump actions/checkout from 4 to 5
- **deps**: bump chrono from 0.4.41 to 0.4.42
- **deps**: bump DeterminateSystems/nix-installer-action from 14 to 19
- remove Windows from CI matrix
- fix all remaining clippy warnings
- add extensive logging to diagnose Windows build failure
- replace let-chains with nested if-let for broader toolchain compatibility (fixes E0658 on Windows)
- fix clippy in build.rs; update cargo-deny; gate llvm-cov in devenv; set Windows toolchain >=1.85
- apply treefmt fixes (CI: --fail-on-change)
- remove generated SBOM artifacts from VCS; CI will generate and upload as artifacts
- **deps**: bump cachix/cachix-action from 12 to 16
- **deps**: bump thiserror from 1.0.69 to 2.0.16
- **deps**: bump lru from 0.12.5 to 0.16.0
- **deps**: bump actions/download-artifact from 4 to 5
- **deps**: bump actions/setup-go from 4 to 5
- apply treefmt formatting fixes
- update CLAUDE.md and WARP.md with recent changes
- improve code coverage with comprehensive test suites
- forcing rebuild with superficial change
- treefmt all the things
- add comprehensive README.md
- lower-case ci workflow names
- remove ffi mutex, fixed concurrency issues
- add Claude development instructions
- add comprehensive test suite achieving 90%+ coverage
- initial project setup with devenv and AGPL license

---

🤖 Generated with [cuenv](https://github.com/cuenv/cuenv)


___

### **PR Type**
Other


___

### **Description**
- Bump workspace version from 0.16.1 to 0.17.0

- Update version in root Cargo.toml for release


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Cargo.toml"] -- "version: 0.16.1 → 0.17.0" --> B["Release 0.17.0"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Cargo.toml</strong><dd><code>Update workspace version to 0.17.0</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Cargo.toml

<ul><li>Update workspace version from 0.16.1 to 0.17.0 in the <br><code>[workspace.package]</code> section</ul>


</details>


  </td>
  <td><a href="https://github.com/cuenv/cuenv/pull/228/files#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

