### PR TITLE
chore(release): prepare release 0.19.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.17.0"
+version = "0.19.0"
 edition = "2024"
 authors = ["cuenv Contributors"]
 license = "AGPL-3.0-or-later"
@@ -39,28 +39,28 @@ keywords = ["cue", "configuration", "validation", "ffi"]
 categories = ["config", "development-tools", "parsing"]
 
 [workspace.dependencies]
-cuenv-events = { path = "crates/events", version = "0.17.0" }
-cuenv-secrets = { path = "crates/secrets", version = "0.17.0" }
-cuenv-core = { path = "crates/core", version = "0.17.0" }
-cuenv-dagger = { path = "crates/dagger", version = "0.17.0" }
-cuenv-workspaces = { path = "crates/workspaces", version = "0.17.0" }
-cuenv-ci = { path = "crates/ci", version = "0.17.0" }
-cuenv-release = { path = "crates/release", version = "0.17.0" }
-cuenv-ignore = { path = "crates/ignore", version = "0.17.0" }
-cuenv-codeowners = { path = "crates/codeowners", version = "0.17.0" }
-cuenv-cubes = { path = "crates/cubes", version = "0.17.0" }
-cuengine = { path = "crates/cuengine", version = "0.17.0" }
+cuenv-events = { path = "crates/events", version = "0.19.0" }
+cuenv-secrets = { path = "crates/secrets", version = "0.19.0" }
+cuenv-core = { path = "crates/core", version = "0.19.0" }
+cuenv-dagger = { path = "crates/dagger", version = "0.19.0" }
+cuenv-workspaces = { path = "crates/workspaces", version = "0.19.0" }
+cuenv-ci = { path = "crates/ci", version = "0.19.0" }
+cuenv-release = { path = "crates/release", version = "0.19.0" }
+cuenv-ignore = { path = "crates/ignore", version = "0.19.0" }
+cuenv-codeowners = { path = "crates/codeowners", version = "0.19.0" }
+cuenv-cubes = { path = "crates/cubes", version = "0.19.0" }
+cuengine = { path = "crates/cuengine", version = "0.19.0" }
 # Platform-specific provider crates
-cuenv-github = { path = "crates/github", version = "0.17.0" }
-cuenv-gitlab = { path = "crates/gitlab", version = "0.17.0" }
-cuenv-bitbucket = { path = "crates/bitbucket", version = "0.17.0" }
-cuenv-buildkite = { path = "crates/buildkite", version = "0.17.0" }
-cuenv-homebrew = { path = "crates/homebrew", version = "0.17.0" }
+cuenv-github = { path = "crates/github", version = "0.19.0" }
+cuenv-gitlab = { path = "crates/gitlab", version = "0.19.0" }
+cuenv-bitbucket = { path = "crates/bitbucket", version = "0.19.0" }
+cuenv-buildkite = { path = "crates/buildkite", version = "0.19.0" }
+cuenv-homebrew = { path = "crates/homebrew", version = "0.19.0" }
 # Secret provider crates
-cuenv-aws = { path = "crates/aws", version = "0.17.0" }
-cuenv-gcp = { path = "crates/gcp", version = "0.17.0" }
-cuenv-vault = { path = "crates/vault", version = "0.17.0" }
-cuenv-1password = { path = "crates/1password", version = "0.17.0" }
+cuenv-aws = { path = "crates/aws", version = "0.19.0" }
+cuenv-gcp = { path = "crates/gcp", version = "0.19.0" }
+cuenv-vault = { path = "crates/vault", version = "0.19.0" }
+cuenv-1password = { path = "crates/1password", version = "0.19.0" }
 schemars = "1.0.4"
 thiserror = "2.0"
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
### **User description**
## Summary

| Package | Current | New | Bump |
|---------|---------|-----|------|
| cuenv-1password | 0.18.0 | 0.19.0 | minor |
| cuenv-homebrew | 0.18.0 | 0.19.0 | minor |
| cuenv-workspaces | 0.18.0 | 0.19.0 | minor |
| cuenv-dagger | 0.18.0 | 0.19.0 | minor |
| cuengine | 0.18.0 | 0.19.0 | minor |
| cuenv | 0.18.0 | 0.19.0 | minor |
| cuenv-ci | 0.18.0 | 0.19.0 | minor |
| cuenv-core | 0.18.0 | 0.19.0 | minor |
| cuenv-codeowners | 0.18.0 | 0.19.0 | minor |
| cuenv-cubes | 0.18.0 | 0.19.0 | minor |
| cuenv-release | 0.18.0 | 0.19.0 | minor |
| cuenv-gitlab | 0.18.0 | 0.19.0 | minor |
| cuenv-bitbucket | 0.18.0 | 0.19.0 | minor |
| cuenv-gcp | 0.18.0 | 0.19.0 | minor |
| cuenv-github | 0.18.0 | 0.19.0 | minor |
| cuenv-secrets | 0.18.0 | 0.19.0 | minor |
| cuenv-aws | 0.18.0 | 0.19.0 | minor |
| cuenv-buildkite | 0.18.0 | 0.19.0 | minor |
| cuenv-events | 0.18.0 | 0.19.0 | minor |
| cuenv-ignore | 0.18.0 | 0.19.0 | minor |
| cuenv-vault | 0.18.0 | 0.19.0 | minor |

## Commits

### Features

- **ci**: add pipeline matrix task support with runner mapping
- **ignore**: wire up cube gitignore patterns in production
- **release**: add unified release prepare command with per-package versioning
- **release**: add release orchestration and Homebrew backend
- **tasks**: allow task groups as dependencies
- **ci**: implement stage-based provider injection architecture
- **ci**: auto-inject 1Password WASM setup step in GitHub workflows
- **secrets**: use OnePasswordResolver batch resolution for op:// refs
- **secrets**: resolve 1Password op:// references at runtime
- **ci**: auto-inject OP_SERVICE_ACCOUNT_TOKEN for 1Password secrets
- **ci**: add environment field to pipelines for secret resolution
- **ci**: add --check flag and sync-check workflow for workflow validation
- **secrets**: add batch resolution with secure memory handling
- **secrets**: add 1Password WASM SDK integration via cuenv secrets setup
- **secrets**: add auto-negotiating dual-mode secret resolvers
- **ci**: add monorepo-ready workflow naming with project prefix
- **ci**: add comprehensive trigger configuration and workflow generation
- **runtime**: add unified runtime model for project and task execution
- **ci**: add per-provider configuration support
- **github**: add workflow file generation with --format github
- **buildkite**: inject Nix bootstrap for tasks with runtime
- **buildkite**: wrap emitted commands with cuenv task
- **ci**: implement IR v1.3 schema and compiler foundation (#212)
- **exec**: warn when hooks not run due to missing approval
- **info**: add module-wide CUE evaluation command
- **owners**: change rules from array to map for CUE layering support
- add gitignore support for cube files and update dependencies
- **vscode**: add auto-completion for dependsOn and task references
- **codegen**: initial implementation of cuenv-codegen (#186)
- implement rich TUI with visual DAG and split-screen task output (#185)
- add code owner support with CODEOWNERS sync (#181)
- add ignorefile support via cuenv sync (#180)
- rich task source metadata and proximity-based listing (#176)
- switch to cargo-zigbuild for Linux releases, optimize CI
- **tasks**: add inputs/outputs to auto-injected install tasks
- dogfood cuenv ci with nix flake check delegation
- add script field for inline shell scripts in tasks (#109)
- add idempotency check for changeset generation in CI
- replace release-plz with native cuenv release management
- **ci**: add crates.io publishing with OIDC
- **ci**: support local changes against references with --from

### Bug Fixes

- resync ci workflows
- **ci**: generate workflows per-project instead of aggregating by pipeline name
- **release**: fix release prepare bugs and buildkite bootstrap
- **release**: use fixed versioning and treat breaking changes as minor in pre-1.0
- resolve clippy uninlined_format_args lint errors
- **release**: canonicalize root path to fix package detection in release prepare
- fast path eval for export (keep shells quick)
- sync github workflows
- couple of minor build/release issues
- **1password**: include secret reference in error messages
- **ci**: gh-models contributor only for pipelines with gh models tasks
- **ci**: resolve three failing workflows on main
- **cli**: show actual errors instead of misleading "No CI configuration found"
- **ci**: enable fixed-point iteration for stage contributors
- ensure release runs on production environment
- kill cargo-audit until nix version is updated
- regen github workflows
- inject cuenv build into ci
- flake caching, hopefully
- correct licneses for aws openssl
- **env**: resolve secrets in env print and fix clippy warnings
- **secrets**: implement 1Password WASM SDK host functions correctly
- **secrets**: use memory_new for WASM and add debug output
- **secrets**: implement 1Password WASM SDK host functions
- **ci**: use unique keys in proptest for env order invariance
- **exec**: redact secret values from command output
- **secrets**: use typed Secret resolver instead of string detection
- resolve all clippy warnings in cuenv-ci crate
- continue resolving clippy warnings
- resolve clippy warnings and code quality issues
- **clippy**: removing more clippy issues
- **buildkite**: improve changed files detection for shallow clones
- **buildkite**: install nix and build cuenv before generating pipeline
- **buildkite**: build cuenv before generating dynamic pipeline
- **ci**: ignore test_custom_shell in sandboxed builds
- **cuengine**: fix race condition in parallel CUE evaluation
- remove hidden fields
- **cuengine**: unquote CUE selector strings for proper JSON keys
- **cubes**: fix test_basic_cube_cue for Nix sandbox environment
- **info**: use CUE schema unification for project detection
- tidy up agents
- update example and tests for cubes package refactor
- update tests to use _examples package name
- address clippy warnings
- release vscode extension with cuenv
- hide examples package from cue publish
- improve performance of starship prompt (#189)
- work around cargo publishing being flakey
- move past partial cargo workspace publish
- default to ease union selection
- still schema fighting
- split task and command to avoid incomplete confusions
- schema was incorrect, needed more embedding
- close taskcommon too
- avoiding incomplete values with close on key types
- build llms.txt issue
- ignore local caches and validate project names
- task discover wasn't picking up taskmatchers properly
- task discovery from cue mod root
- dont rely on previous release artifacts
- schema inconsistencies for tasks and taskgroups
- cue schema for tasks
- dependencies on task groups now supported
- run all release pipeline tasks unconditionally
- include llms.txt and env.cue in nix build source
- dag bug for group tasks / added llmx.txt evals
- rust action name
- clippy linting
- treefmt
- ensure we exit non-zero for individual tgask failures
- remove awful CUEnv accident
- disable macos temporarily
- use setup-cuenv
- adopt zigbuild, remove musl
- graceful shallow clone handling for CI, optimize workflow
- actually run static in CI for confirmation
- attempting to fix static build
- hopefully static and go play nice
- documentation link to cuenv.dev
- id-token permission to release workflow
- attempting to fix static builds once and for all
- **nix**: skip tests for static musl builds
- bump to 0.10.1
- **ci**: remove temporary version_summary.txt file from release PRs
- **nix**: add binutils for Linux builds of libcue-bridge
- **ci**: error when pipeline not found instead of silently doing nothing
- **ci**: fail fast when running outside cue.mod directory
- treefmt
- read me badges (#100)
- **nix**: improve Crane source filtering for proper build caching
- git needed for build
- linting, builds, and json flags for release
- bugs
- improve error handling in manifest and release modules
- resolve clippy warnings in release management code
- address all PR review feedback
- ci improvements
- auth with crates properly and cut  0.8.6
- build static binaries

### Other Changes

- **release**: prepare release 0.17.0 (#228)
- 0.16.1
- **sync**: introduce provider-based architecture with SyncMode enum
- sync ci workflows
- **cli**: move CI workflow generation to `cuenv sync ci`
- **commands**: reduce mod.rs from 2,050 to 535 lines
- **task**: add TaskExecutionRequest structured API
- **task**: extract normalization, resolution, and workspace modules
- **task**: split task.rs into modular directory structure
- 0.16.0
- add warning about rapid API/schema iteration
- **secrets**: extract providers into separate crates
- update documentation for 0.16.0 release (#215)
- complete CLEANUP.md - remove unwrap/expect, add functional patterns
- apply Rust coding standards from CLEANUP.md
- mark internal crates as non-publishable
- add temporary debug output for 1Password resolver
- debugging
- use typed #OnePasswordRef for production secrets
- **secrets**: add tests for EnvValue resolution including op:// refs
- **deps**: migrate from OpenSSL to rustls for TLS
- migrate CI/CD variables to 1Password
- fix formatting issues
- add formatter options, although basic for now, to task output
- **cuengine**: optimize CUE evaluation with parallel and targeted modes
- pass CommandExecutor through hook evaluation chain
- **cli**: wire up CommandExecutor event-driven architecture
- **cuengine**: unify CUE evaluation through evaluate_module
- **sync**: simplify CODEOWNERS sync output
- **owners**: remove defaultOwners in favor of catch-all rules
- 0.15.7
- cleanup and refactoring
- move owners/ignore to Base schema and fix sync -A performance
- update security isolation status in readme
- **vscode**: update to use --all flag for workspace tasks
- rename --workspace to --all on task command
- 0.15.6
- minor updates
- 0.15.5
- refactoring VCS provider into crates and strippping CUE tests from mod publish
- improve cubes docs to make it clear it's codegen with a funny name
- 0.15.4
- add cubes, and update ignore/owners
- 0.15.3
- move code file types to separate cubes package
- adopt cuenv ignores and owners
- replace .unwrap() with .expect() in production code
- use platform-appropriate paths via dirs crate
- fix cargo fmt
- 0.15.0
- separate sync/async command paths for faster CLI startup
- make cuenv crates useful as standalone libraries (#182)
- 0.14.1
- 0.14.0
- add comprehensive DAG builder tests for cross-project and hooks (#179)
- 0.13.0
- close more defs
- 0.12.5
- fmt
- 0.12.2
- overhaul
- make the examples tests
- generators are really just taskmatchers
- 0.12.0
- 0.11.7
- 0.11.5
- 0.11.2
- 0.11.1
- switch to Blacksmith runners for GitHub Actions
- use setup-cuenv action in release-pr workflow
- use pre-built cuenv binary for CI orchestration
- use pre-built binary for release-pr workflow
- 0.10.3
- migrate from magic-nix-cache to Cachix
- 0.10.1
- release (#155)
- remove droid
- extract git helper functions in tests
- add coverage for execute_changeset_from_commits with since_tag
- address code review style suggestions
- improve package path handling and version validation
- rename internal crate directories
- release v0.8.4
- 0.8.5
- 0.8.4
- bunch of cleanups

---

🤖 Generated with [cuenv](https://github.com/cuenv/cuenv)


___

### **PR Type**
Other


___

### **Description**
- Update workspace version from 0.17.0 to 0.19.0

- Bump all internal crate dependencies to 0.19.0

- Synchronize versions across 21 packages in monorepo


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Cargo.toml<br/>workspace.package"] -- "version: 0.17.0 → 0.19.0" --> B["Updated<br/>workspace version"]
  C["workspace.dependencies<br/>21 crates"] -- "all versions: 0.17.0 → 0.19.0" --> D["Synchronized<br/>crate versions"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Cargo.toml</strong><dd><code>Synchronize all workspace versions to 0.19.0</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Cargo.toml

<ul><li>Update workspace package version from 0.17.0 to 0.19.0<br> <li> Bump all 21 internal crate dependencies to 0.19.0<br> <li> Includes core, ci, secrets, events, release, ignore, codeowners, <br>cubes, cuengine, github, gitlab, bitbucket, buildkite, homebrew, aws, <br>gcp, vault, and 1password crates</ul>


</details>


  </td>
  <td><a href="https://github.com/cuenv/cuenv/pull/229/files#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542">+21/-21</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

