### PR TITLE
chore(release): prepare release 0.20.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.19.1"
+version = "0.20.0"
 edition = "2024"
 authors = ["cuenv Contributors"]
 license = "AGPL-3.0-or-later"
@@ -39,28 +39,28 @@ keywords = ["cue", "configuration", "validation", "ffi"]
 categories = ["config", "development-tools", "parsing"]
 
 [workspace.dependencies]
-cuenv-events = { path = "crates/events", version = "0.19.0" }
-cuenv-secrets = { path = "crates/secrets", version = "0.19.0" }
-cuenv-core = { path = "crates/core", version = "0.19.0" }
-cuenv-dagger = { path = "crates/dagger", version = "0.19.0" }
-cuenv-workspaces = { path = "crates/workspaces", version = "0.19.0" }
-cuenv-ci = { path = "crates/ci", version = "0.19.0" }
-cuenv-release = { path = "crates/release", version = "0.19.0" }
-cuenv-ignore = { path = "crates/ignore", version = "0.19.0" }
-cuenv-codeowners = { path = "crates/codeowners", version = "0.19.0" }
-cuenv-cubes = { path = "crates/cubes", version = "0.19.0" }
-cuengine = { path = "crates/cuengine", version = "0.19.0" }
+cuenv-events = { path = "crates/events", version = "0.20.0" }
+cuenv-secrets = { path = "crates/secrets", version = "0.20.0" }
+cuenv-core = { path = "crates/core", version = "0.20.0" }
+cuenv-dagger = { path = "crates/dagger", version = "0.20.0" }
+cuenv-workspaces = { path = "crates/workspaces", version = "0.20.0" }
+cuenv-ci = { path = "crates/ci", version = "0.20.0" }
+cuenv-release = { path = "crates/release", version = "0.20.0" }
+cuenv-ignore = { path = "crates/ignore", version = "0.20.0" }
+cuenv-codeowners = { path = "crates/codeowners", version = "0.20.0" }
+cuenv-cubes = { path = "crates/cubes", version = "0.20.0" }
+cuengine = { path = "crates/cuengine", version = "0.20.0" }
 # Platform-specific provider crates
-cuenv-github = { path = "crates/github", version = "0.19.0" }
-cuenv-gitlab = { path = "crates/gitlab", version = "0.19.0" }
-cuenv-bitbucket = { path = "crates/bitbucket", version = "0.19.0" }
-cuenv-buildkite = { path = "crates/buildkite", version = "0.19.0" }
-cuenv-homebrew = { path = "crates/homebrew", version = "0.19.0" }
+cuenv-github = { path = "crates/github", version = "0.20.0" }
+cuenv-gitlab = { path = "crates/gitlab", version = "0.20.0" }
+cuenv-bitbucket = { path = "crates/bitbucket", version = "0.20.0" }
+cuenv-buildkite = { path = "crates/buildkite", version = "0.20.0" }
+cuenv-homebrew = { path = "crates/homebrew", version = "0.20.0" }
 # Secret provider crates
-cuenv-aws = { path = "crates/aws", version = "0.19.0" }
-cuenv-gcp = { path = "crates/gcp", version = "0.19.0" }
-cuenv-vault = { path = "crates/vault", version = "0.19.0" }
-cuenv-1password = { path = "crates/1password", version = "0.19.0" }
+cuenv-aws = { path = "crates/aws", version = "0.20.0" }
+cuenv-gcp = { path = "crates/gcp", version = "0.20.0" }
+cuenv-vault = { path = "crates/vault", version = "0.20.0" }
+cuenv-1password = { path = "crates/1password", version = "0.20.0" }
 schemars = "1.0.4"
 thiserror = "2.0"
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
### **User description**
## Summary

| Package | Current | New | Bump |
|---------|---------|-----|------|
| cuengine | 0.19.1 | 0.20.0 | minor |
| cuenv-cubes | 0.19.1 | 0.20.0 | minor |
| cuenv-vault | 0.19.1 | 0.20.0 | minor |
| cuenv-buildkite | 0.19.1 | 0.20.0 | minor |
| cuenv-codeowners | 0.19.1 | 0.20.0 | minor |
| cuenv-gitlab | 0.19.1 | 0.20.0 | minor |
| cuenv-aws | 0.19.1 | 0.20.0 | minor |
| cuenv | 0.19.1 | 0.20.0 | minor |
| cuenv-ci | 0.19.1 | 0.20.0 | minor |
| cuenv-1password | 0.19.1 | 0.20.0 | minor |
| cuenv-core | 0.19.1 | 0.20.0 | minor |
| cuenv-homebrew | 0.19.1 | 0.20.0 | minor |
| cuenv-secrets | 0.19.1 | 0.20.0 | minor |
| cuenv-gcp | 0.19.1 | 0.20.0 | minor |
| cuenv-workspaces | 0.19.1 | 0.20.0 | minor |
| cuenv-bitbucket | 0.19.1 | 0.20.0 | minor |
| cuenv-ignore | 0.19.1 | 0.20.0 | minor |
| cuenv-release | 0.19.1 | 0.20.0 | minor |
| cuenv-github | 0.19.1 | 0.20.0 | minor |
| cuenv-events | 0.19.1 | 0.20.0 | minor |
| cuenv-dagger | 0.19.1 | 0.20.0 | minor |

## Commits

### Features

- **ci**: expand cuenv source configuration with git, nix, homebrew, release modes
- **ci**: add StageRenderer abstraction for platform-agnostic contributor rendering

### Bug Fixes

- **ci**: ensure nix build failures propagate and normalize workflow formatting
- **release**: use semver-aware tag detection instead of string sorting
- remove untracked/needed pipelines


---

🤖 Generated with [cuenv](https://github.com/cuenv/cuenv)


___

### **PR Type**
Other


___

### **Description**
- Bump workspace version from 0.19.1 to 0.20.0

- Update all internal crate dependencies to 0.20.0

- Synchronize versions across 21 packages in workspace


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Cargo.toml<br/>workspace.package"] -- "version: 0.19.1 → 0.20.0" --> B["Updated<br/>workspace version"]
  C["workspace.dependencies"] -- "all crates: 0.19.0 → 0.20.0" --> D["Synchronized<br/>crate versions"]
  B --> E["Release 0.20.0"]
  D --> E
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Cargo.toml</strong><dd><code>Bump all workspace and crate versions to 0.20.0</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Cargo.toml

<ul><li>Updated workspace version from 0.19.1 to 0.20.0<br> <li> Bumped all 13 internal workspace dependencies from 0.19.0 to 0.20.0<br> <li> Updated platform-specific provider crates (github, gitlab, bitbucket, <br>buildkite, homebrew)<br> <li> Updated secret provider crates (aws, gcp, vault, 1password)</ul>


</details>


  </td>
  <td><a href="https://github.com/cuenv/cuenv/pull/231/files#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542">+21/-21</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

