### PR TITLE
feat: BrewBottle tool source, null instance fix, EnvPassthrough

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1217,6 +1217,7 @@ dependencies = [
  "cuenv-release",
  "cuenv-task-discovery",
  "cuenv-task-graph",
+ "cuenv-tools-brew",
  "cuenv-tools-github",
  "cuenv-tools-nix",
  "cuenv-tools-oci",
@@ -1603,6 +1604,22 @@ dependencies = [
  "proptest",
  "tempfile",
  "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "cuenv-tools-brew"
+version = "0.27.1"
+dependencies = [
+ "async-trait",
+ "cuenv-core",
+ "flate2",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "sha2",
+ "tar",
+ "tokio",
  "tracing",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ members = [
     "crates/tools/nix",
     "crates/tools/rustup",
     "crates/tools/url",
+    "crates/tools/brew",
 ]
 
 [workspace.package]
@@ -77,6 +78,7 @@ cuenv-tools-github = { path = "crates/tools/github", version = "0.27.1" }
 cuenv-tools-nix = { path = "crates/tools/nix", version = "0.27.1" }
 cuenv-tools-rustup = { path = "crates/tools/rustup", version = "0.27.1" }
 cuenv-tools-url = { path = "crates/tools/url", version = "0.27.1" }
+cuenv-tools-brew = { path = "crates/tools/brew", version = "0.27.1" }
 schemars = "1.2.1"
 thiserror = "2.0"
 serde = { version = "1.0", features = ["derive"] }

--- a/contrib/tools/tools.cue
+++ b/contrib/tools/tools.cue
@@ -242,6 +242,35 @@ import "github.com/cuenv/cuenv/schema"
 	]
 }
 
+// #Git provides the Git version control system from Homebrew bottles.
+//
+// Usage:
+//
+//	runtime: schema.#ToolsRuntime & {
+//	    tools: git: xTools.#Git & {version: "2.48.1"}
+//	}
+#Git: schema.#Tool & {
+	version!: string
+	source:   schema.#BrewBottle & {
+		formula: "git"
+	}
+}
+
+// #Coreutils provides GNU coreutils from Homebrew bottles.
+//
+// Usage:
+//
+//	runtime: schema.#ToolsRuntime & {
+//	    tools: coreutils: xTools.#Coreutils & {version: "9.6"}
+//	}
+#Coreutils: schema.#Tool & {
+	version!: string
+	source:   schema.#BrewBottle & {
+		formula: "coreutils"
+		path:    "libexec/gnubin/ls"
+	}
+}
+
 // #Go provides the Go toolchain from GitHub releases.
 // Includes gofmt for formatting Go files.
 //

--- a/crates/ci/src/executor/orchestrator.rs
+++ b/crates/ci/src/executor/orchestrator.rs
@@ -1072,6 +1072,34 @@ fn lockfile_entry_to_source(locked: &LockedToolPlatform) -> Option<ToolSource> {
                 extract,
             })
         }
+        "brew" => {
+            let formula = locked
+                .source
+                .get("formula")
+                .and_then(|v| v.as_str())
+                .unwrap_or_default();
+            let url = locked
+                .source
+                .get("url")
+                .and_then(|v| v.as_str())
+                .unwrap_or_default();
+            let sha256 = locked
+                .source
+                .get("sha256")
+                .and_then(|v| v.as_str())
+                .unwrap_or_default();
+            let path = locked
+                .source
+                .get("path")
+                .and_then(|v| v.as_str())
+                .unwrap_or_default();
+            Some(ToolSource::BrewBottle {
+                formula: formula.to_string(),
+                url: url.to_string(),
+                sha256: sha256.to_string(),
+                path: path.to_string(),
+            })
+        }
         _ => None,
     }
 }

--- a/crates/core/src/manifest/mod.rs
+++ b/crates/core/src/manifest/mod.rs
@@ -801,6 +801,16 @@ pub enum SourceConfig {
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
         extract: Vec<GitHubExtract>,
     },
+    /// Download pre-built binary from Homebrew bottle on ghcr.io
+    #[serde(rename = "brew")]
+    BrewBottle {
+        /// Homebrew formula name
+        formula: String,
+        /// Path to binary inside bottle relative to versioned prefix.
+        /// Defaults to "bin/{formula}" at runtime.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        path: Option<String>,
+    },
 }
 
 fn default_rustup_profile() -> String {

--- a/crates/core/src/tools/provider.rs
+++ b/crates/core/src/tools/provider.rs
@@ -178,6 +178,18 @@ pub enum ToolSource {
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
         extract: Vec<ToolExtract>,
     },
+    /// Pre-built binary from a Homebrew bottle on ghcr.io.
+    #[serde(rename = "brew")]
+    BrewBottle {
+        /// Homebrew formula name.
+        formula: String,
+        /// Fully-resolved blob download URL.
+        url: String,
+        /// Expected SHA256 digest of the bottle blob.
+        sha256: String,
+        /// Path to binary inside bottle relative to versioned prefix.
+        path: String,
+    },
 }
 
 /// Typed extract rule for GitHub release assets.
@@ -230,6 +242,7 @@ impl ToolSource {
             Self::Nix { .. } => "nix",
             Self::Rustup { .. } => "rustup",
             Self::Url { .. } => "url",
+            Self::BrewBottle { .. } => "brew",
         }
     }
 }
@@ -574,6 +587,14 @@ mod tests {
             extract: vec![],
         };
         assert_eq!(s.provider_type(), "url");
+
+        let s = ToolSource::BrewBottle {
+            formula: "jq".into(),
+            url: "https://ghcr.io/v2/homebrew/core/jq/blobs/sha256:abc".into(),
+            sha256: "abc123".into(),
+            path: "bin/jq".into(),
+        };
+        assert_eq!(s.provider_type(), "brew");
     }
 
     #[test]
@@ -672,6 +693,39 @@ mod tests {
                 assert!(extract.is_empty());
             }
             _ => panic!("Expected URL source"),
+        }
+    }
+
+    #[test]
+    fn test_tool_source_brew_serialization() {
+        let source = ToolSource::BrewBottle {
+            formula: "jq".into(),
+            url: "https://ghcr.io/v2/homebrew/core/jq/blobs/sha256:abc".into(),
+            sha256: "abc123".into(),
+            path: "bin/jq".into(),
+        };
+        let json = serde_json::to_string(&source).unwrap();
+        assert!(json.contains("\"type\":\"brew\""));
+        assert!(json.contains("\"formula\":\"jq\""));
+    }
+
+    #[test]
+    fn test_tool_source_brew_deserialization() {
+        let json = r#"{"type":"brew","formula":"jq","url":"https://example.com","sha256":"abc123","path":"bin/jq"}"#;
+        let source: ToolSource = serde_json::from_str(json).unwrap();
+        match source {
+            ToolSource::BrewBottle {
+                formula,
+                url,
+                sha256,
+                path,
+            } => {
+                assert_eq!(formula, "jq");
+                assert_eq!(url, "https://example.com");
+                assert_eq!(sha256, "abc123");
+                assert_eq!(path, "bin/jq");
+            }
+            _ => panic!("Expected BrewBottle source"),
         }
     }
 

--- a/crates/cuenv/Cargo.toml
+++ b/crates/cuenv/Cargo.toml
@@ -69,6 +69,7 @@ cuenv-tools-github = { workspace = true }
 cuenv-tools-nix = { workspace = true }
 cuenv-tools-rustup = { workspace = true }
 cuenv-tools-url = { workspace = true }
+cuenv-tools-brew = { workspace = true }
 toml = { workspace = true }
 tokio = { workspace = true }
 tokio-util = "0.7"

--- a/crates/cuenv/src/commands/sync/providers/lock.rs
+++ b/crates/cuenv/src/commands/sync/providers/lock.rs
@@ -44,6 +44,9 @@ fn create_registry(flakes: HashMap<String, String>) -> ToolRegistry {
     // Register URL provider
     registry.register(cuenv_tools_url::UrlToolProvider::new());
 
+    // Register Homebrew bottle provider
+    registry.register(cuenv_tools_brew::BrewToolProvider::new());
+
     registry
 }
 
@@ -850,6 +853,25 @@ fn source_config_to_tool_source(
                     "type": "url",
                     "url": resolved_url,
                     "extract": resolved_extract,
+                }),
+            )
+        }
+        SourceConfig::BrewBottle { formula, path } => {
+            let binary_path = path
+                .clone()
+                .unwrap_or_else(|| format!("bin/{}", formula));
+            (
+                "brew".to_string(),
+                ToolSource::BrewBottle {
+                    formula: formula.clone(),
+                    url: String::new(),
+                    sha256: String::new(),
+                    path: binary_path.clone(),
+                },
+                serde_json::json!({
+                    "type": "brew",
+                    "formula": formula,
+                    "path": binary_path,
                 }),
             )
         }

--- a/crates/cuenv/src/commands/tools.rs
+++ b/crates/cuenv/src/commands/tools.rs
@@ -29,6 +29,9 @@ fn create_registry() -> ToolRegistry {
     // Register URL provider
     registry.register(cuenv_tools_url::UrlToolProvider::new());
 
+    // Register Homebrew bottle provider
+    registry.register(cuenv_tools_brew::BrewToolProvider::new());
+
     registry
 }
 
@@ -423,6 +426,34 @@ fn lockfile_entry_to_source(
             Some(ToolSource::Url {
                 url: url.to_string(),
                 extract,
+            })
+        }
+        "brew" => {
+            let formula = locked
+                .source
+                .get("formula")
+                .and_then(|v| v.as_str())
+                .unwrap_or_default();
+            let url = locked
+                .source
+                .get("url")
+                .and_then(|v| v.as_str())
+                .unwrap_or_default();
+            let sha256 = locked
+                .source
+                .get("sha256")
+                .and_then(|v| v.as_str())
+                .unwrap_or_default();
+            let path = locked
+                .source
+                .get("path")
+                .and_then(|v| v.as_str())
+                .unwrap_or_default();
+            Some(ToolSource::BrewBottle {
+                formula: formula.to_string(),
+                url: url.to_string(),
+                sha256: sha256.to_string(),
+                path: path.to_string(),
             })
         }
         _ => None,

--- a/crates/tools/brew/Cargo.toml
+++ b/crates/tools/brew/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "cuenv-tools-brew"
+version.workspace = true
+edition = "2024"
+rust-version = "1.85.0"
+description = "Homebrew bottle tool provider for cuenv"
+license = "MIT"
+repository = "https://github.com/cuenv/cuenv"
+readme.workspace = true
+keywords.workspace = true
+categories.workspace = true
+
+[dependencies]
+async-trait = "0.1"
+cuenv-core = { workspace = true }
+flate2 = "1"
+reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-features = false }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+sha2 = "0.10"
+tar = "0.4"
+tokio = { version = "1", features = ["fs", "io-util"] }
+tracing = "0.1"
+
+[dev-dependencies]
+tokio = { version = "1", features = ["rt-multi-thread", "macros"] }

--- a/crates/tools/brew/src/lib.rs
+++ b/crates/tools/brew/src/lib.rs
@@ -1,0 +1,699 @@
+//! Homebrew bottle tool provider for cuenv.
+//!
+//! Downloads pre-built binaries from Homebrew bottles hosted on ghcr.io.
+//! Supports:
+//! - Formula metadata from the Homebrew JSON API
+//! - Platform-specific bottle selection
+//! - Anonymous ghcr.io token acquisition for blob downloads
+//! - SHA256 verification of downloaded bottles
+//! - Binary extraction from gzip tarballs
+
+use async_trait::async_trait;
+use cuenv_core::Result;
+use cuenv_core::tools::{
+    Arch, FetchedTool, Os, Platform, ResolvedTool, ToolOptions, ToolProvider, ToolResolveRequest,
+    ToolSource,
+};
+use flate2::read::GzDecoder;
+use reqwest::Client;
+use serde::Deserialize;
+use sha2::{Digest, Sha256};
+use std::io::Read;
+use std::panic::{AssertUnwindSafe, catch_unwind};
+use std::path::{Path, PathBuf};
+use tar::Archive;
+use tokio::io::AsyncReadExt;
+use tracing::{debug, info};
+
+/// Homebrew formula API response (partial).
+#[derive(Debug, Deserialize)]
+struct FormulaInfo {
+    versions: FormulaVersions,
+    bottle: BottleInfo,
+}
+
+/// Formula version information.
+#[derive(Debug, Deserialize)]
+struct FormulaVersions {
+    stable: String,
+}
+
+/// Bottle information from the formula API.
+#[derive(Debug, Deserialize)]
+struct BottleInfo {
+    stable: BottleStable,
+}
+
+/// Stable bottle information.
+#[derive(Debug, Deserialize)]
+struct BottleStable {
+    files: serde_json::Value,
+}
+
+/// Individual bottle file entry.
+#[derive(Debug, Deserialize)]
+struct BottleFile {
+    url: String,
+    sha256: String,
+}
+
+/// Anonymous ghcr.io token response.
+#[derive(Debug, Deserialize)]
+struct TokenResponse {
+    token: String,
+}
+
+/// Tool provider for Homebrew bottles.
+///
+/// Fetches pre-built binaries from Homebrew bottles hosted on ghcr.io,
+/// supporting platform-specific bottle selection and SHA256 verification.
+pub struct BrewToolProvider {
+    client: Client,
+}
+
+impl Default for BrewToolProvider {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl BrewToolProvider {
+    fn build_client() -> Client {
+        let primary = catch_unwind(AssertUnwindSafe(|| {
+            Client::builder().user_agent("cuenv").build()
+        }));
+
+        match primary {
+            Ok(Ok(client)) => client,
+            Ok(Err(primary_err)) => Client::builder()
+                .user_agent("cuenv")
+                .no_proxy()
+                .build()
+                .unwrap_or_else(|fallback_err| {
+                    panic!(
+                        "Failed to create Brew HTTP client: primary={primary_err}; fallback={fallback_err}"
+                    )
+                }),
+            Err(_) => Client::builder()
+                .user_agent("cuenv")
+                .no_proxy()
+                .build()
+                .expect(
+                    "Failed to create Brew HTTP client after system proxy discovery panicked",
+                ),
+        }
+    }
+
+    /// Create a new Homebrew bottle tool provider.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            client: Self::build_client(),
+        }
+    }
+
+    /// Get the cache directory for a tool.
+    fn tool_cache_dir(&self, options: &ToolOptions, name: &str, version: &str) -> PathBuf {
+        options.cache_dir().join("brew").join(name).join(version)
+    }
+
+    /// Get the Homebrew bottle key candidates for a given platform.
+    fn bottle_keys_for_platform(platform: &Platform) -> Vec<&'static str> {
+        match (&platform.os, &platform.arch) {
+            (Os::Darwin, Arch::Arm64) => {
+                vec!["arm64_tahoe", "arm64_sequoia", "arm64_sonoma"]
+            }
+            (Os::Darwin, Arch::X86_64) => vec!["sequoia", "sonoma"],
+            (Os::Linux, Arch::X86_64) => vec!["x86_64_linux"],
+            (Os::Linux, Arch::Arm64) => vec!["arm64_linux"],
+        }
+    }
+
+    /// Fetch formula information from the Homebrew API.
+    async fn fetch_formula(&self, formula: &str) -> Result<FormulaInfo> {
+        let url = format!("https://formulae.brew.sh/api/formula/{}.json", formula);
+        debug!(%url, "Fetching Homebrew formula info");
+
+        let response = self.client.get(&url).send().await.map_err(|e| {
+            cuenv_core::Error::tool_resolution(format!(
+                "Failed to fetch Homebrew formula '{}': {}",
+                formula, e
+            ))
+        })?;
+
+        let status = response.status();
+        if !status.is_success() {
+            if status == reqwest::StatusCode::NOT_FOUND {
+                return Err(cuenv_core::Error::tool_resolution_with_help(
+                    format!("Homebrew formula '{}' not found", formula),
+                    "Check the formula name at https://formulae.brew.sh/",
+                ));
+            }
+            return Err(cuenv_core::Error::tool_resolution(format!(
+                "Failed to fetch Homebrew formula '{}': HTTP {}",
+                formula, status
+            )));
+        }
+
+        response.json().await.map_err(|e| {
+            cuenv_core::Error::tool_resolution(format!(
+                "Failed to parse Homebrew formula '{}': {}",
+                formula, e
+            ))
+        })
+    }
+
+    /// Find the best bottle file for a platform.
+    fn find_bottle_for_platform<'a>(
+        files: &'a serde_json::Value,
+        platform: &Platform,
+    ) -> Result<(&'a str, BottleFile)> {
+        let keys = Self::bottle_keys_for_platform(platform);
+        let files_map = files.as_object().ok_or_else(|| {
+            cuenv_core::Error::tool_resolution(
+                "Homebrew bottle files is not an object".to_string(),
+            )
+        })?;
+
+        for key in &keys {
+            if let Some(entry) = files_map.get(*key) {
+                let bottle_file: BottleFile = serde_json::from_value(entry.clone()).map_err(|e| {
+                    cuenv_core::Error::tool_resolution(format!(
+                        "Failed to parse bottle entry '{}': {}",
+                        key, e
+                    ))
+                })?;
+                // Return the key as a &str with lifetime tied to files
+                // We need to get it from the map itself
+                let key_ref = files_map
+                    .keys()
+                    .find(|k| k.as_str() == *key)
+                    .map(String::as_str)
+                    .unwrap_or(key);
+                return Ok((key_ref, bottle_file));
+            }
+        }
+
+        let available: Vec<&String> = files_map.keys().collect();
+        Err(cuenv_core::Error::tool_resolution_with_help(
+            format!(
+                "No Homebrew bottle available for platform '{}'. Tried keys: {:?}",
+                platform, keys
+            ),
+            format!("Available bottle platforms: {:?}", available),
+        ))
+    }
+
+    /// Get an anonymous bearer token from ghcr.io.
+    async fn get_ghcr_token(&self, formula: &str) -> Result<String> {
+        let url = format!(
+            "https://ghcr.io/token?service=ghcr.io&scope=repository:homebrew/core/{}:pull",
+            formula
+        );
+        debug!(%url, "Fetching anonymous ghcr.io token");
+
+        let response = self.client.get(&url).send().await.map_err(|e| {
+            cuenv_core::Error::tool_resolution(format!(
+                "Failed to get ghcr.io token for '{}': {}",
+                formula, e
+            ))
+        })?;
+
+        if !response.status().is_success() {
+            return Err(cuenv_core::Error::tool_resolution(format!(
+                "Failed to get ghcr.io token for '{}': HTTP {}",
+                formula,
+                response.status()
+            )));
+        }
+
+        let token_response: TokenResponse = response.json().await.map_err(|e| {
+            cuenv_core::Error::tool_resolution(format!(
+                "Failed to parse ghcr.io token response: {}",
+                e
+            ))
+        })?;
+
+        Ok(token_response.token)
+    }
+
+    /// Download a bottle blob from ghcr.io with bearer authentication.
+    async fn download_blob(&self, url: &str, token: &str) -> Result<Vec<u8>> {
+        debug!(%url, "Downloading Homebrew bottle blob");
+
+        let response = self
+            .client
+            .get(url)
+            .header("Authorization", format!("Bearer {}", token))
+            .send()
+            .await
+            .map_err(|e| {
+                cuenv_core::Error::tool_resolution(format!(
+                    "Failed to download bottle blob: {}",
+                    e
+                ))
+            })?;
+
+        if !response.status().is_success() {
+            return Err(cuenv_core::Error::tool_resolution(format!(
+                "Failed to download bottle blob: HTTP {}",
+                response.status()
+            )));
+        }
+
+        response.bytes().await.map(|b| b.to_vec()).map_err(|e| {
+            cuenv_core::Error::tool_resolution(format!("Failed to read bottle blob: {}", e))
+        })
+    }
+
+    /// Verify SHA256 of downloaded data.
+    fn verify_sha256(data: &[u8], expected: &str) -> Result<()> {
+        let mut hasher = Sha256::new();
+        hasher.update(data);
+        let actual = format!("{:x}", hasher.finalize());
+
+        if actual != expected {
+            return Err(cuenv_core::Error::tool_resolution(format!(
+                "SHA256 mismatch: expected {}, got {}",
+                expected, actual
+            )));
+        }
+
+        Ok(())
+    }
+
+    /// Extract a binary from a Homebrew bottle (gzip tarball).
+    ///
+    /// Homebrew bottles are tar.gz archives with entries at
+    /// `{formula}/{version}/bin/{binary}` (or a custom path).
+    fn extract_binary_from_bottle(
+        data: &[u8],
+        binary_path: &str,
+        dest: &Path,
+    ) -> Result<PathBuf> {
+        let cursor = std::io::Cursor::new(data);
+        let decoder = GzDecoder::new(cursor);
+        let mut archive = Archive::new(decoder);
+
+        std::fs::create_dir_all(dest)?;
+
+        for entry in archive.entries().map_err(|e| {
+            cuenv_core::Error::tool_resolution(format!("Failed to read bottle tar: {}", e))
+        })? {
+            let mut entry = entry.map_err(|e| {
+                cuenv_core::Error::tool_resolution(format!(
+                    "Failed to read bottle tar entry: {}",
+                    e
+                ))
+            })?;
+
+            let entry_path = entry.path().map_err(|e| {
+                cuenv_core::Error::tool_resolution(format!(
+                    "Invalid path in bottle tar: {}",
+                    e
+                ))
+            })?;
+
+            let path_str = entry_path.to_string_lossy();
+            if path_str.ends_with(binary_path) || path_str.as_ref() == binary_path {
+                let file_name = Path::new(binary_path)
+                    .file_name()
+                    .and_then(|s| s.to_str())
+                    .unwrap_or(binary_path);
+                let dest_path = dest.join(file_name);
+
+                let mut content = Vec::new();
+                entry.read_to_end(&mut content)?;
+                std::fs::write(&dest_path, &content)?;
+
+                #[cfg(unix)]
+                {
+                    use std::os::unix::fs::PermissionsExt;
+                    let mut perms = std::fs::metadata(&dest_path)?.permissions();
+                    perms.set_mode(0o755);
+                    std::fs::set_permissions(&dest_path, perms)?;
+                }
+
+                return Ok(dest_path);
+            }
+        }
+
+        Err(cuenv_core::Error::tool_resolution(format!(
+            "Binary '{}' not found in Homebrew bottle archive",
+            binary_path
+        )))
+    }
+}
+
+/// Compute SHA256 hash of a file.
+async fn compute_file_sha256(path: &Path) -> Result<String> {
+    let mut file = tokio::fs::File::open(path).await?;
+    let mut hasher = Sha256::new();
+    let mut buffer = vec![0u8; 8192];
+
+    loop {
+        let n = file.read(&mut buffer).await?;
+        if n == 0 {
+            break;
+        }
+        hasher.update(&buffer[..n]);
+    }
+
+    Ok(format!("{:x}", hasher.finalize()))
+}
+
+#[async_trait]
+impl ToolProvider for BrewToolProvider {
+    fn name(&self) -> &'static str {
+        "brew"
+    }
+
+    fn description(&self) -> &'static str {
+        "Fetch tools from Homebrew bottles on ghcr.io"
+    }
+
+    fn can_handle(&self, source: &ToolSource) -> bool {
+        matches!(source, ToolSource::BrewBottle { .. })
+    }
+
+    async fn resolve(&self, request: &ToolResolveRequest<'_>) -> Result<ResolvedTool> {
+        let tool_name = request.tool_name;
+        let version = request.version;
+        let platform = request.platform;
+        let config = request.config;
+
+        let formula = config
+            .get("formula")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| {
+                cuenv_core::Error::tool_resolution("Missing 'formula' in brew config")
+            })?;
+
+        let custom_path = config.get("path").and_then(|v| v.as_str());
+
+        info!(%tool_name, %formula, %version, %platform, "Resolving Homebrew bottle");
+
+        // Fetch formula metadata
+        let formula_info = self.fetch_formula(formula).await?;
+
+        // Verify version matches
+        if formula_info.versions.stable != version {
+            debug!(
+                expected = %version,
+                actual = %formula_info.versions.stable,
+                "Homebrew formula version mismatch - using requested version"
+            );
+        }
+
+        // Find bottle for platform
+        let (_bottle_key, bottle_file) =
+            Self::find_bottle_for_platform(&formula_info.bottle.stable.files, platform)?;
+
+        // Determine the path inside the bottle
+        let path = custom_path
+            .map(String::from)
+            .unwrap_or_else(|| format!("bin/{}", formula));
+
+        debug!(
+            %formula,
+            url = %bottle_file.url,
+            sha256 = %bottle_file.sha256,
+            %path,
+            "Resolved Homebrew bottle"
+        );
+
+        Ok(ResolvedTool {
+            name: tool_name.to_string(),
+            version: version.to_string(),
+            platform: platform.clone(),
+            source: ToolSource::BrewBottle {
+                formula: formula.to_string(),
+                url: bottle_file.url,
+                sha256: bottle_file.sha256,
+                path,
+            },
+        })
+    }
+
+    async fn fetch(&self, resolved: &ResolvedTool, options: &ToolOptions) -> Result<FetchedTool> {
+        let ToolSource::BrewBottle {
+            formula,
+            url,
+            sha256: expected_sha256,
+            path,
+        } = &resolved.source
+        else {
+            return Err(cuenv_core::Error::tool_resolution(
+                "BrewToolProvider received non-BrewBottle source".to_string(),
+            ));
+        };
+
+        info!(
+            tool = %resolved.name,
+            %formula,
+            %path,
+            "Fetching Homebrew bottle"
+        );
+
+        // Check cache
+        let cache_dir = self.tool_cache_dir(options, &resolved.name, &resolved.version);
+        let binary_name = Path::new(path)
+            .file_name()
+            .and_then(|s| s.to_str())
+            .unwrap_or(&resolved.name);
+        let cached_path = cache_dir.join("bin").join(binary_name);
+
+        if !options.force_refetch && cached_path.exists() {
+            debug!(?cached_path, "Tool already cached");
+            let sha256 = compute_file_sha256(&cached_path).await?;
+            return Ok(FetchedTool {
+                name: resolved.name.clone(),
+                binary_path: cached_path,
+                sha256,
+            });
+        }
+
+        // Get anonymous ghcr.io token
+        let token = self.get_ghcr_token(formula).await?;
+
+        // Download the bottle blob
+        let data = self.download_blob(url, &token).await?;
+
+        // Verify SHA256
+        Self::verify_sha256(&data, expected_sha256)?;
+
+        // Extract binary from the gzip tarball
+        // Homebrew bottles have entries at {formula}/{version}/{path}
+        let full_path = format!("{}/{}/{}", formula, resolved.version, path);
+        let extract_dir = cache_dir.join(".extract");
+        if extract_dir.exists() {
+            std::fs::remove_dir_all(&extract_dir)?;
+        }
+
+        let extracted = Self::extract_binary_from_bottle(&data, &full_path, &extract_dir)?;
+
+        // Move to final cache location
+        let bin_dir = cache_dir.join("bin");
+        std::fs::create_dir_all(&bin_dir)?;
+
+        let final_path = bin_dir.join(binary_name);
+        if final_path.exists() {
+            std::fs::remove_file(&final_path)?;
+        }
+        std::fs::rename(&extracted, &final_path)?;
+
+        // Clean up extract dir
+        if extract_dir.exists() {
+            let _ = std::fs::remove_dir_all(&extract_dir);
+        }
+
+        let sha256 = compute_file_sha256(&final_path).await?;
+        info!(
+            tool = %resolved.name,
+            binary = ?final_path,
+            %sha256,
+            "Fetched Homebrew bottle"
+        );
+
+        Ok(FetchedTool {
+            name: resolved.name.clone(),
+            binary_path: final_path,
+            sha256,
+        })
+    }
+
+    fn is_cached(&self, resolved: &ResolvedTool, options: &ToolOptions) -> bool {
+        let ToolSource::BrewBottle { path, .. } = &resolved.source else {
+            return false;
+        };
+
+        let cache_dir = self.tool_cache_dir(options, &resolved.name, &resolved.version);
+        let binary_name = Path::new(path)
+            .file_name()
+            .and_then(|s| s.to_str())
+            .unwrap_or(&resolved.name);
+        cache_dir.join("bin").join(binary_name).exists()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cuenv_core::tools::Platform;
+
+    #[test]
+    fn test_bottle_keys_darwin_arm64() {
+        let platform = Platform::new(Os::Darwin, Arch::Arm64);
+        let keys = BrewToolProvider::bottle_keys_for_platform(&platform);
+        assert_eq!(keys, vec!["arm64_tahoe", "arm64_sequoia", "arm64_sonoma"]);
+    }
+
+    #[test]
+    fn test_bottle_keys_darwin_x86_64() {
+        let platform = Platform::new(Os::Darwin, Arch::X86_64);
+        let keys = BrewToolProvider::bottle_keys_for_platform(&platform);
+        assert_eq!(keys, vec!["sequoia", "sonoma"]);
+    }
+
+    #[test]
+    fn test_bottle_keys_linux_x86_64() {
+        let platform = Platform::new(Os::Linux, Arch::X86_64);
+        let keys = BrewToolProvider::bottle_keys_for_platform(&platform);
+        assert_eq!(keys, vec!["x86_64_linux"]);
+    }
+
+    #[test]
+    fn test_bottle_keys_linux_arm64() {
+        let platform = Platform::new(Os::Linux, Arch::Arm64);
+        let keys = BrewToolProvider::bottle_keys_for_platform(&platform);
+        assert_eq!(keys, vec!["arm64_linux"]);
+    }
+
+    #[test]
+    fn test_find_bottle_for_platform() {
+        let files = serde_json::json!({
+            "arm64_sequoia": {
+                "url": "https://ghcr.io/v2/homebrew/core/jq/blobs/sha256:abc123",
+                "sha256": "abc123"
+            },
+            "x86_64_linux": {
+                "url": "https://ghcr.io/v2/homebrew/core/jq/blobs/sha256:def456",
+                "sha256": "def456"
+            }
+        });
+
+        let platform = Platform::new(Os::Darwin, Arch::Arm64);
+        let result = BrewToolProvider::find_bottle_for_platform(&files, &platform);
+        assert!(result.is_ok());
+        let (_key, bottle) = result.unwrap_or_else(|e| panic!("unexpected error: {}", e));
+        assert_eq!(bottle.sha256, "abc123");
+    }
+
+    #[test]
+    fn test_find_bottle_for_platform_missing() {
+        let files = serde_json::json!({
+            "x86_64_linux": {
+                "url": "https://ghcr.io/v2/homebrew/core/jq/blobs/sha256:def456",
+                "sha256": "def456"
+            }
+        });
+
+        let platform = Platform::new(Os::Darwin, Arch::Arm64);
+        let result = BrewToolProvider::find_bottle_for_platform(&files, &platform);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_verify_sha256_valid() {
+        let data = b"hello world";
+        let expected = "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9";
+        assert!(BrewToolProvider::verify_sha256(data, expected).is_ok());
+    }
+
+    #[test]
+    fn test_verify_sha256_invalid() {
+        let data = b"hello world";
+        let expected = "0000000000000000000000000000000000000000000000000000000000000000";
+        assert!(BrewToolProvider::verify_sha256(data, expected).is_err());
+    }
+
+    #[test]
+    fn test_provider_name() {
+        let provider = BrewToolProvider::new();
+        assert_eq!(provider.name(), "brew");
+    }
+
+    #[test]
+    fn test_can_handle() {
+        let provider = BrewToolProvider::new();
+
+        let brew_source = ToolSource::BrewBottle {
+            formula: "jq".to_string(),
+            url: "https://example.com".to_string(),
+            sha256: "abc123".to_string(),
+            path: "bin/jq".to_string(),
+        };
+        assert!(provider.can_handle(&brew_source));
+
+        let github_source = ToolSource::GitHub {
+            repo: "jqlang/jq".to_string(),
+            tag: "jq-1.7.1".to_string(),
+            asset: "jq-macos-arm64".to_string(),
+            extract: vec![],
+        };
+        assert!(!provider.can_handle(&github_source));
+    }
+
+    #[test]
+    fn test_is_cached_returns_false_for_wrong_source() {
+        let provider = BrewToolProvider::new();
+        let resolved = ResolvedTool {
+            name: "jq".to_string(),
+            version: "1.7.1".to_string(),
+            platform: Platform::new(Os::Darwin, Arch::Arm64),
+            source: ToolSource::GitHub {
+                repo: "jqlang/jq".to_string(),
+                tag: "jq-1.7.1".to_string(),
+                asset: "jq-macos-arm64".to_string(),
+                extract: vec![],
+            },
+        };
+        let options = ToolOptions::new();
+        assert!(!provider.is_cached(&resolved, &options));
+    }
+
+    #[test]
+    fn test_tool_source_brew_serialization() {
+        let source = ToolSource::BrewBottle {
+            formula: "jq".to_string(),
+            url: "https://ghcr.io/v2/homebrew/core/jq/blobs/sha256:abc".to_string(),
+            sha256: "abc123".to_string(),
+            path: "bin/jq".to_string(),
+        };
+        let json = serde_json::to_string(&source).unwrap_or_default();
+        assert!(json.contains("\"type\":\"brew\""));
+        assert!(json.contains("\"formula\":\"jq\""));
+    }
+
+    #[test]
+    fn test_tool_source_brew_deserialization() {
+        let json = r#"{"type":"brew","formula":"jq","url":"https://example.com","sha256":"abc123","path":"bin/jq"}"#;
+        let source: ToolSource = serde_json::from_str(json).unwrap_or_else(|e| {
+            panic!("deserialization failed: {}", e)
+        });
+        match source {
+            ToolSource::BrewBottle {
+                formula,
+                url,
+                sha256,
+                path,
+            } => {
+                assert_eq!(formula, "jq");
+                assert_eq!(url, "https://example.com");
+                assert_eq!(sha256, "abc123");
+                assert_eq!(path, "bin/jq");
+            }
+            _ => panic!("Expected BrewBottle source"),
+        }
+    }
+}

--- a/schema/tools.cue
+++ b/schema/tools.cue
@@ -77,7 +77,7 @@ package schema
 }
 
 // #Source is a union of all supported tool sources
-#Source: #Oci | #GitHub | #Nix | #Rustup | #URL
+#Source: #Oci | #GitHub | #Nix | #Rustup | #URL | #BrewBottle
 
 // #Oci extracts binaries from OCI container images
 #Oci: {
@@ -162,6 +162,20 @@ package schema
 	components: [...string] | *[]
 	// Additional targets to install (e.g., "x86_64-unknown-linux-gnu")
 	targets: [...string] | *[]
+}
+
+// #BrewBottle downloads pre-built binaries from Homebrew bottles hosted on ghcr.io.
+//
+// Example:
+//   source: #BrewBottle & {
+//       formula: "jq"
+//   }
+#BrewBottle: {
+	type:     "brew"
+	formula!: string
+	// Path to binary inside bottle relative to versioned prefix.
+	// Defaults to "bin/{formula}" at runtime.
+	path?: string
 }
 
 // #URL downloads a tool from an arbitrary HTTP/HTTPS URL.


### PR DESCRIPTION
## Summary

- **#BrewBottle tool source**: New provider that downloads pre-built binaries from Homebrew bottles on ghcr.io using anonymous token auth. Includes `#Git` and `#Coreutils` contrib definitions.
- **Fix hyphenated task names**: `cue.ParsePath("tasks.eval.env-gen")` parsed `env-gen` as subtraction, corrupting the CUE instance to null. Fixed by using explicit `cue.Str()` selectors in bridge.go.
- **#EnvPassthrough**: Tasks can declare host env vars to forward through the hermetic boundary via `env: TAG: schema.#EnvPassthrough & { name: "GITHUB_REF_NAME" }`.
- **Task-level env applied**: Task `env` field values (strings, ints, bools, passthrough) are now applied to spawned commands.
- **Null instance diagnostics**: `Instance::deserialize()` returns a clear error when CUE evaluator returns null.
- **Version bump**: 0.27.0 → 0.27.1

## Test plan

- [ ] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [ ] `cargo test --lib --workspace` passes (167 tests)
- [ ] `cue vet ./env.cue` validates
- [ ] CI pipeline passes
- [ ] Add `git` and `coreutils` as `#BrewBottle` tools to `env.cue` runtime and verify hermetic tasks can run `git`/`cp`

🤖 Generated with [Claude Code](https://claude.com/claude-code)