### PR TITLE
feat(schema): add #ContainerImage type and cuenv build command

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -21,20 +21,10 @@
       "Bash(done)",
       "Bash(for i in 1 2 3 4 5)",
       "Bash(xargs -I {} sh -c 'awk \"\"/^[[:space:]]*\\(pub[[:space:]]+\\)?\\(async[[:space:]]+\\)?fn[[:space:]]+[^\\(]+\\\\\\(/ { start=NR; fn=\\\\$0; params=0; in_fn=1 } in_fn { line=\\\\$0; gsub\\(/\\\\/\\\\/.*/, \\\\\"\"\\\\\"\", line\\); if \\(line ~ /\\\\\\(/\\) params++; if \\(line ~ /\\\\\\)/\\) { params--; if \\(params == 0\\) { param_count = gsub\\(/,/, \\\\\"\"\\\\\"\", fn \\\\$0\\); if \\(param_count > 3\\) print FILENAME \\\\\"\":\\\\\"\" start \\\\\"\":\\\\\"\" fn; in_fn=0 } } else if \\(in_fn\\) fn = fn \\\\\"\" \\\\\"\" \\\\$0 }\"\" {}')",
-      "Bash(ls:*)",
-      "Bash(grep -rn crates/task-graph /Users/rawkode/Code/src/github.com/cuenv/cuenv/*.nix /Users/rawkode/Code/src/github.com/cuenv/cuenv/nix/)",
+      "Bash(nix develop:*)",
       "Bash(nix flake:*)",
-      "Bash(tee /tmp/nix-check.log)",
-      "Bash(nix log:*)",
-      "Bash(tee /tmp/nix-check2.log)",
-      "Bash(tee /tmp/nix-check3.log)",
-      "Bash(tee /tmp/nix-check4.log)",
-      "Bash(tee /tmp/nix-check5.log)",
-      "Bash(tee /tmp/nix-check6.log)",
-      "Bash(tee /tmp/nix-check7.log)",
-      "Bash(tee /tmp/nix-check8.log)",
-      "Bash(tee /tmp/nix-check9.log)",
-      "Bash(tee /tmp/nix-check10.log)"
+      "Bash(jj status:*)",
+      "Bash(jj describe:*)"
     ]
   }
 }

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -21,10 +21,20 @@
       "Bash(done)",
       "Bash(for i in 1 2 3 4 5)",
       "Bash(xargs -I {} sh -c 'awk \"\"/^[[:space:]]*\\(pub[[:space:]]+\\)?\\(async[[:space:]]+\\)?fn[[:space:]]+[^\\(]+\\\\\\(/ { start=NR; fn=\\\\$0; params=0; in_fn=1 } in_fn { line=\\\\$0; gsub\\(/\\\\/\\\\/.*/, \\\\\"\"\\\\\"\", line\\); if \\(line ~ /\\\\\\(/\\) params++; if \\(line ~ /\\\\\\)/\\) { params--; if \\(params == 0\\) { param_count = gsub\\(/,/, \\\\\"\"\\\\\"\", fn \\\\$0\\); if \\(param_count > 3\\) print FILENAME \\\\\"\":\\\\\"\" start \\\\\"\":\\\\\"\" fn; in_fn=0 } } else if \\(in_fn\\) fn = fn \\\\\"\" \\\\\"\" \\\\$0 }\"\" {}')",
-      "Bash(nix develop:*)",
+      "Bash(ls:*)",
+      "Bash(grep -rn crates/task-graph /Users/rawkode/Code/src/github.com/cuenv/cuenv/*.nix /Users/rawkode/Code/src/github.com/cuenv/cuenv/nix/)",
       "Bash(nix flake:*)",
-      "Bash(jj status:*)",
-      "Bash(jj describe:*)"
+      "Bash(tee /tmp/nix-check.log)",
+      "Bash(nix log:*)",
+      "Bash(tee /tmp/nix-check2.log)",
+      "Bash(tee /tmp/nix-check3.log)",
+      "Bash(tee /tmp/nix-check4.log)",
+      "Bash(tee /tmp/nix-check5.log)",
+      "Bash(tee /tmp/nix-check6.log)",
+      "Bash(tee /tmp/nix-check7.log)",
+      "Bash(tee /tmp/nix-check8.log)",
+      "Bash(tee /tmp/nix-check9.log)",
+      "Bash(tee /tmp/nix-check10.log)"
     ]
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,7 @@
 - It doesn't matter if it's pre-existing, we fix issues; we don't swerve accountability.
 - We always use Nix for builds and checks, cuenv for everything Nix isn't good at.
 - We cannot commit any code if `nix flake check -L --accept-flake-config` is not passing.
+- Always update ./docs for all work
 
 ## Project Overview
 

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -461,6 +461,13 @@ impl From<cuenv_task_graph::Error> for Error {
                 ))
             }
             cuenv_task_graph::Error::TopologicalSortFailed { .. } => None,
+            cuenv_task_graph::Error::DuplicateNodeName {
+                name,
+                existing_kind,
+                new_kind,
+            } => Some(format!(
+                "Rename the {new_kind} '{name}' to avoid collision with the existing {existing_kind}"
+            )),
         };
         Error::TaskGraph {
             message: err.to_string(),

--- a/crates/core/src/manifest/mod.rs
+++ b/crates/core/src/manifest/mod.rs
@@ -953,6 +953,98 @@ fn default_service_type() -> String {
     "service".to_string()
 }
 
+// ============================================================================
+// Container Image Types
+// ============================================================================
+
+/// Output reference for a container image (ref or digest).
+///
+/// Mirrors [`TaskOutputRef`] but for image build outputs. The executor
+/// resolves these at runtime after the image is built.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ImageOutputRef {
+    #[serde(rename = "cuenvOutputRef")]
+    pub cuenv_output_ref: bool,
+    #[serde(rename = "cuenvImage")]
+    pub cuenv_image: String,
+    #[serde(rename = "cuenvOutput")]
+    pub cuenv_output: String,
+}
+
+/// Container image build definition.
+///
+/// Declares a container image as a first-class project artifact. Images
+/// participate in the task DAG and produce output references (`.ref`,
+/// `.digest`) that downstream tasks can consume.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ContainerImage {
+    /// Type discriminator — always `"image"`.
+    #[serde(rename = "type", default = "default_image_type")]
+    pub image_type: String,
+
+    /// Image reference output — resolved at runtime after build.
+    #[serde(rename = "ref")]
+    pub ref_output: ImageOutputRef,
+
+    /// Image digest output — resolved at runtime after build.
+    pub digest: ImageOutputRef,
+
+    /// Build context directory (required).
+    pub context: String,
+
+    /// Dockerfile path relative to context.
+    #[serde(default = "default_dockerfile")]
+    pub dockerfile: String,
+
+    /// Build arguments (values may be literal strings or image output refs).
+    #[serde(default, rename = "buildArgs", skip_serializing_if = "HashMap::is_empty")]
+    pub build_args: HashMap<String, serde_json::Value>,
+
+    /// Target stage for multi-stage builds.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub target: Option<String>,
+
+    /// Image tags (e.g., `["latest", "v1.0.0"]`).
+    #[serde(default)]
+    pub tags: Vec<String>,
+
+    /// Registry to push to (omit for local-only builds).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub registry: Option<String>,
+
+    /// Repository name (defaults to image name if omitted).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub repository: Option<String>,
+
+    /// Target platforms for multi-arch builds.
+    #[serde(default)]
+    pub platform: Vec<String>,
+
+    /// Dependencies on tasks or other images.
+    #[serde(default, rename = "dependsOn")]
+    pub depends_on: Vec<TaskDependency>,
+
+    /// Labels for discovery.
+    #[serde(default)]
+    pub labels: Vec<String>,
+
+    /// Input files/patterns for cache key derivation.
+    #[serde(default)]
+    pub inputs: Vec<Input>,
+
+    /// Human-readable description.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+}
+
+fn default_image_type() -> String {
+    "image".to_string()
+}
+
+fn default_dockerfile() -> String {
+    "Dockerfile".to_string()
+}
+
 /// Readiness probe — discriminated by `kind` field.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "kind")]
@@ -1186,6 +1278,10 @@ pub struct Project {
     /// Services configuration — long-running supervised processes.
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub services: HashMap<String, Service>,
+
+    /// Container image build definitions.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub images: HashMap<String, ContainerImage>,
 
     /// Codegen configuration for code generation
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/core/src/manifest/mod.rs
+++ b/crates/core/src/manifest/mod.rs
@@ -997,7 +997,11 @@ pub struct ContainerImage {
     pub dockerfile: String,
 
     /// Build arguments (values may be literal strings or image output refs).
-    #[serde(default, rename = "buildArgs", skip_serializing_if = "HashMap::is_empty")]
+    #[serde(
+        default,
+        rename = "buildArgs",
+        skip_serializing_if = "HashMap::is_empty"
+    )]
     pub build_args: HashMap<String, serde_json::Value>,
 
     /// Target stage for multi-stage builds.

--- a/crates/core/src/module.rs
+++ b/crates/core/src/module.rs
@@ -20,9 +20,15 @@ pub type ReferenceMap = HashMap<String, String>;
 /// service prefixes, including common let-binding aliases.
 fn strip_dependency_prefix(path: &str) -> &str {
     const DEP_PREFIXES: &[&str] = &[
-        "tasks.", "_tasks.", "_t.",
-        "services.", "_services.", "_s.",
-        "images.", "_images.", "_i.",
+        "tasks.",
+        "_tasks.",
+        "_t.",
+        "services.",
+        "_services.",
+        "_s.",
+        "images.",
+        "_images.",
+        "_i.",
     ];
     for prefix in DEP_PREFIXES {
         if let Some(stripped) = path.strip_prefix(prefix) {

--- a/crates/core/src/module.rs
+++ b/crates/core/src/module.rs
@@ -19,7 +19,11 @@ pub type ReferenceMap = HashMap<String, String>;
 /// The CUE bridge exports raw reference paths which may include task or
 /// service prefixes, including common let-binding aliases.
 fn strip_dependency_prefix(path: &str) -> &str {
-    const DEP_PREFIXES: &[&str] = &["tasks.", "_tasks.", "_t.", "services.", "_services.", "_s."];
+    const DEP_PREFIXES: &[&str] = &[
+        "tasks.", "_tasks.", "_t.",
+        "services.", "_services.", "_s.",
+        "images.", "_images.", "_i.",
+    ];
     for prefix in DEP_PREFIXES {
         if let Some(stripped) = path.strip_prefix(prefix) {
             return stripped;

--- a/crates/core/src/tasks/output_refs.rs
+++ b/crates/core/src/tasks/output_refs.rs
@@ -290,8 +290,7 @@ fn try_extract_output_ref(value: &serde_json::Value) -> Option<String> {
 #[must_use]
 pub fn has_output_refs(args: &[String], env: &HashMap<String, serde_json::Value>) -> bool {
     let has_ref = |s: &str| s.starts_with(OUTPUT_REF_PREFIX) || s.starts_with(IMAGE_REF_PREFIX);
-    args.iter().any(|a| has_ref(a))
-        || env.values().any(|v| v.as_str().is_some_and(has_ref))
+    args.iter().any(|a| has_ref(a)) || env.values().any(|v| v.as_str().is_some_and(has_ref))
 }
 
 /// Context for resolving task output reference placeholders at runtime.

--- a/crates/core/src/tasks/output_refs.rs
+++ b/crates/core/src/tasks/output_refs.rs
@@ -19,6 +19,10 @@ use std::collections::HashMap;
 /// Format: `cuenv:ref:<task_name>:<output_field>`
 const OUTPUT_REF_PREFIX: &str = "cuenv:ref:";
 
+/// Prefix for placeholder strings that represent image output references.
+/// Format: `cuenv:image-ref:<image_name>:<ref|digest>`
+const IMAGE_REF_PREFIX: &str = "cuenv:image-ref:";
+
 /// Prefix for placeholder strings that represent host env passthrough.
 /// Format: `cuenv:passthrough:<var_name>`
 const PASSTHROUGH_PREFIX: &str = "cuenv:passthrough:";
@@ -237,7 +241,7 @@ pub fn parse_passthrough(s: &str) -> Option<&str> {
     s.strip_prefix(PASSTHROUGH_PREFIX)
 }
 
-/// Try to extract a `#TaskOutputRef` from a JSON value.
+/// Try to extract a `#TaskOutputRef` or `#ImageOutputRef` from a JSON value.
 /// Returns the placeholder string if the value is a ref object, None otherwise.
 fn try_extract_output_ref(value: &serde_json::Value) -> Option<String> {
     let obj = value.as_object()?;
@@ -252,21 +256,32 @@ fn try_extract_output_ref(value: &serde_json::Value) -> Option<String> {
         return None;
     }
 
-    let task = obj.get("cuenvTask")?.as_str()?;
-    let output = obj.get("cuenvOutput")?.as_str()?;
+    // Task output ref: { cuenvOutputRef: true, cuenvTask: "...", cuenvOutput: "stdout"|"stderr"|"exitCode" }
+    if let Some(task) = obj.get("cuenvTask").and_then(|v| v.as_str()) {
+        let output = obj.get("cuenvOutput")?.as_str()?;
+        let output_field = match output {
+            "stdout" => TaskOutputField::Stdout,
+            "stderr" => TaskOutputField::Stderr,
+            "exitCode" => TaskOutputField::ExitCode,
+            _ => return None,
+        };
+        let r = TaskOutputRef {
+            task: task.to_string(),
+            output: output_field,
+        };
+        return Some(r.to_placeholder());
+    }
 
-    let output_field = match output {
-        "stdout" => TaskOutputField::Stdout,
-        "stderr" => TaskOutputField::Stderr,
-        "exitCode" => TaskOutputField::ExitCode,
-        _ => return None,
-    };
+    // Image output ref: { cuenvOutputRef: true, cuenvImage: "...", cuenvOutput: "ref"|"digest" }
+    if let Some(image) = obj.get("cuenvImage").and_then(|v| v.as_str()) {
+        let output = obj.get("cuenvOutput")?.as_str()?;
+        if output != "ref" && output != "digest" {
+            return None;
+        }
+        return Some(format!("{IMAGE_REF_PREFIX}{image}:{output}"));
+    }
 
-    let r = TaskOutputRef {
-        task: task.to_string(),
-        output: output_field,
-    };
-    Some(r.to_placeholder())
+    None
 }
 
 /// Returns `true` if any string in `args` or `env` contains an output ref placeholder.
@@ -274,10 +289,9 @@ fn try_extract_output_ref(value: &serde_json::Value) -> Option<String> {
 /// Use this as a fast check to avoid cloning tasks that have no refs to resolve.
 #[must_use]
 pub fn has_output_refs(args: &[String], env: &HashMap<String, serde_json::Value>) -> bool {
-    args.iter().any(|a| a.starts_with(OUTPUT_REF_PREFIX))
-        || env
-            .values()
-            .any(|v| v.as_str().is_some_and(|s| s.starts_with(OUTPUT_REF_PREFIX)))
+    let has_ref = |s: &str| s.starts_with(OUTPUT_REF_PREFIX) || s.starts_with(IMAGE_REF_PREFIX);
+    args.iter().any(|a| has_ref(a))
+        || env.values().any(|v| v.as_str().is_some_and(has_ref))
 }
 
 /// Context for resolving task output reference placeholders at runtime.

--- a/crates/cuenv/src/cli.rs
+++ b/crates/cuenv/src/cli.rs
@@ -760,6 +760,37 @@ pub enum Commands {
         #[command(subcommand)]
         subcommand: ToolsCommands,
     },
+    /// Build container images defined in CUE configuration.
+    #[command(about = "Build container images defined in CUE configuration")]
+    Build {
+        /// Image names to build (default: list all).
+        #[arg(help = "Image names to build (default: list all)")]
+        names: Vec<String>,
+        /// Path to directory containing CUE files.
+        #[arg(
+            long,
+            short = 'p',
+            help = "Path to directory containing CUE files",
+            default_value = "."
+        )]
+        path: String,
+        /// Name of the CUE package to evaluate.
+        #[arg(
+            long,
+            help = "Name of the CUE package to evaluate",
+            default_value = "cuenv"
+        )]
+        package: String,
+        /// Filter images by label (repeatable).
+        #[arg(
+            long = "label",
+            short = 'l',
+            action = clap::ArgAction::Append,
+            help = "Filter images by label (repeatable)",
+            value_name = "LABEL"
+        )]
+        labels: Vec<String>,
+    },
     /// Bring up long-running services.
     #[command(about = "Bring up long-running services defined in CUE configuration")]
     Up {
@@ -1433,6 +1464,7 @@ impl Commands {
             | Self::Allow { package, .. }
             | Self::Deny { package, .. }
             | Self::Export { package, .. }
+            | Self::Build { package, .. }
             | Self::Up { package, .. }
             | Self::Down { package, .. }
             | Self::Logs { package, .. }
@@ -1821,6 +1853,17 @@ impl Commands {
                 ToolsCommands::Download => Command::ToolsDownload,
                 ToolsCommands::Activate => Command::ToolsActivate,
                 ToolsCommands::List => Command::ToolsList,
+            },
+            Self::Build {
+                names,
+                path,
+                package,
+                labels,
+            } => Command::Build {
+                path,
+                package,
+                names,
+                labels,
             },
             Self::Up {
                 services,

--- a/crates/cuenv/src/commands/build.rs
+++ b/crates/cuenv/src/commands/build.rs
@@ -32,10 +32,7 @@ pub struct BuildOptions {
 /// # Errors
 ///
 /// Returns an error if CUE evaluation or deserialization fails.
-pub fn execute_build(
-    options: &BuildOptions,
-    executor: &CommandExecutor,
-) -> cuenv_core::Result<()> {
+pub fn execute_build(options: &BuildOptions, executor: &CommandExecutor) -> cuenv_core::Result<()> {
     let target_path =
         Path::new(&options.path)
             .canonicalize()
@@ -106,7 +103,9 @@ pub fn execute_build(
         ));
     }
 
-    emit_stdout!("\ncuenv build: execution backends not yet implemented — schema validated successfully");
+    emit_stdout!(
+        "\ncuenv build: execution backends not yet implemented — schema validated successfully"
+    );
     Ok(())
 }
 
@@ -120,8 +119,7 @@ fn filter_images(
         .iter()
         .filter(|(name, image)| {
             let name_match = names.is_empty() || names.contains(name);
-            let label_match =
-                labels.is_empty() || labels.iter().any(|l| image.labels.contains(l));
+            let label_match = labels.is_empty() || labels.iter().any(|l| image.labels.contains(l));
             name_match && label_match
         })
         .map(|(name, image)| (name.clone(), image.clone()))

--- a/crates/cuenv/src/commands/build.rs
+++ b/crates/cuenv/src/commands/build.rs
@@ -1,0 +1,195 @@
+//! Implementation of the `cuenv build` command.
+//!
+//! Evaluates the CUE configuration, discovers container image definitions,
+//! and either lists available images or validates what would be built.
+//! Actual execution backends (Dagger, Docker CLI) are future work.
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use cuenv_core::manifest::{ContainerImage, Project};
+use cuenv_events::emit_stdout;
+
+use super::{CommandExecutor, relative_path_from_root};
+
+/// Options for the `cuenv build` command.
+pub struct BuildOptions {
+    /// Path to directory containing CUE files.
+    pub path: String,
+    /// CUE package name to evaluate.
+    pub package: String,
+    /// Image names to build (empty = list all).
+    pub names: Vec<String>,
+    /// Label filters to select images by labels.
+    pub labels: Vec<String>,
+}
+
+/// Execute the `cuenv build` command.
+///
+/// Evaluates CUE configuration, discovers image definitions, and either
+/// lists available images or validates the build configuration.
+///
+/// # Errors
+///
+/// Returns an error if CUE evaluation or deserialization fails.
+pub fn execute_build(
+    options: &BuildOptions,
+    executor: &CommandExecutor,
+) -> cuenv_core::Result<()> {
+    let target_path =
+        Path::new(&options.path)
+            .canonicalize()
+            .map_err(|e| cuenv_core::Error::Io {
+                source: e,
+                path: Some(Path::new(&options.path).to_path_buf().into_boxed_path()),
+                operation: "canonicalize path".to_string(),
+            })?;
+
+    let module = executor.get_module(&target_path)?;
+    let relative_path = relative_path_from_root(&module.root, &target_path);
+
+    let instance = module.get(&relative_path).ok_or_else(|| {
+        cuenv_core::Error::configuration(format!(
+            "No CUE instance found at path: {} (relative: {})",
+            target_path.display(),
+            relative_path.display()
+        ))
+    })?;
+
+    let project: Project = instance.deserialize()?;
+
+    if project.images.is_empty() {
+        emit_stdout!("cuenv build: no images defined in configuration");
+        return Ok(());
+    }
+
+    // No image name specified → list all images
+    if options.names.is_empty() && options.labels.is_empty() {
+        emit_stdout!("Available images:\n");
+        for (name, image) in &project.images {
+            let desc = image
+                .description
+                .as_deref()
+                .map_or(String::new(), |d| format!("  {d}"));
+            let tags = if image.tags.is_empty() {
+                String::new()
+            } else {
+                format!(" [{}]", image.tags.join(", "))
+            };
+            emit_stdout!(format!("  {name}{tags}{desc}"));
+        }
+        return Ok(());
+    }
+
+    let filtered = filter_images(&project.images, &options.names, &options.labels);
+
+    if filtered.is_empty() {
+        emit_stdout!("cuenv build: no images match the specified filters");
+        return Ok(());
+    }
+
+    // Phase 1: validate and print what would be built.
+    // Execution backends will be added in follow-up work.
+    for (name, image) in &filtered {
+        let registry = image
+            .registry
+            .as_deref()
+            .map_or(String::from("local"), |r| r.to_string());
+        let platforms = if image.platform.is_empty() {
+            String::from("native")
+        } else {
+            image.platform.join(", ")
+        };
+        emit_stdout!(format!(
+            "cuenv build: {name} (context: {}, dockerfile: {}, registry: {registry}, platform: {platforms})",
+            image.context, image.dockerfile
+        ));
+    }
+
+    emit_stdout!("\ncuenv build: execution backends not yet implemented — schema validated successfully");
+    Ok(())
+}
+
+/// Filter images by name and label.
+fn filter_images(
+    all_images: &HashMap<String, ContainerImage>,
+    names: &[String],
+    labels: &[String],
+) -> HashMap<String, ContainerImage> {
+    all_images
+        .iter()
+        .filter(|(name, image)| {
+            let name_match = names.is_empty() || names.contains(name);
+            let label_match =
+                labels.is_empty() || labels.iter().any(|l| image.labels.contains(l));
+            name_match && label_match
+        })
+        .map(|(name, image)| (name.clone(), image.clone()))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cuenv_core::manifest::ImageOutputRef;
+
+    fn test_image(tags: Vec<&str>, labels: Vec<&str>) -> ContainerImage {
+        ContainerImage {
+            image_type: "image".to_string(),
+            ref_output: ImageOutputRef {
+                cuenv_output_ref: true,
+                cuenv_image: "test".to_string(),
+                cuenv_output: "ref".to_string(),
+            },
+            digest: ImageOutputRef {
+                cuenv_output_ref: true,
+                cuenv_image: "test".to_string(),
+                cuenv_output: "digest".to_string(),
+            },
+            context: ".".to_string(),
+            dockerfile: "Dockerfile".to_string(),
+            build_args: HashMap::new(),
+            target: None,
+            tags: tags.into_iter().map(String::from).collect(),
+            registry: None,
+            repository: None,
+            platform: vec![],
+            depends_on: vec![],
+            labels: labels.into_iter().map(String::from).collect(),
+            inputs: vec![],
+            description: None,
+        }
+    }
+
+    #[test]
+    fn test_filter_images_no_filters() {
+        let mut images = HashMap::new();
+        images.insert("api".to_string(), test_image(vec!["latest"], vec![]));
+        images.insert("worker".to_string(), test_image(vec!["latest"], vec![]));
+
+        let result = filter_images(&images, &[], &[]);
+        assert_eq!(result.len(), 2);
+    }
+
+    #[test]
+    fn test_filter_images_by_name() {
+        let mut images = HashMap::new();
+        images.insert("api".to_string(), test_image(vec!["latest"], vec![]));
+        images.insert("worker".to_string(), test_image(vec!["latest"], vec![]));
+
+        let result = filter_images(&images, &["api".to_string()], &[]);
+        assert_eq!(result.len(), 1);
+        assert!(result.contains_key("api"));
+    }
+
+    #[test]
+    fn test_filter_images_by_label() {
+        let mut images = HashMap::new();
+        images.insert("api".to_string(), test_image(vec!["latest"], vec!["ci"]));
+        images.insert("worker".to_string(), test_image(vec!["latest"], vec![]));
+
+        let result = filter_images(&images, &[], &["ci".to_string()]);
+        assert_eq!(result.len(), 1);
+        assert!(result.contains_key("api"));
+    }
+}

--- a/crates/cuenv/src/commands/export.rs
+++ b/crates/cuenv/src/commands/export.rs
@@ -1096,6 +1096,7 @@ mod tests {
             runtime: None,
             formatters: None,
             services: HashMap::new(),
+            images: HashMap::new(),
         };
 
         let vars = extract_static_env_vars(&cfg);
@@ -1129,6 +1130,7 @@ mod tests {
             runtime: None,
             formatters: None,
             services: HashMap::new(),
+            images: HashMap::new(),
         };
 
         let hook_env = HashMap::from([

--- a/crates/cuenv/src/commands/hooks.rs
+++ b/crates/cuenv/src/commands/hooks.rs
@@ -871,6 +871,7 @@ mod tests {
             formatters: None,
             runtime: None,
             services: std::collections::HashMap::new(),
+            images: std::collections::HashMap::new(),
         };
 
         let hooks = extract_hooks_from_config(&config);
@@ -915,6 +916,7 @@ mod tests {
             formatters: None,
             runtime: None,
             services: std::collections::HashMap::new(),
+            images: std::collections::HashMap::new(),
         };
 
         let hooks = extract_hooks_from_config(&config);
@@ -938,6 +940,7 @@ mod tests {
             formatters: None,
             runtime: None,
             services: std::collections::HashMap::new(),
+            images: std::collections::HashMap::new(),
         };
 
         let hooks = extract_hooks_from_config(&config);

--- a/crates/cuenv/src/commands/mod.rs
+++ b/crates/cuenv/src/commands/mod.rs
@@ -1,3 +1,5 @@
+/// Build container images defined in CUE configuration.
+pub mod build;
 /// Interactive changeset picker for selecting changes to include.
 pub mod changeset_picker;
 /// CI pipeline integration and generation commands.
@@ -356,6 +358,17 @@ pub enum Command {
     ToolsActivate,
     /// List configured tools.
     ToolsList,
+    /// Build container images defined in CUE configuration.
+    Build {
+        /// Path to the CUE module or project directory.
+        path: String,
+        /// CUE package name to evaluate.
+        package: String,
+        /// Image names to build (empty = list all).
+        names: Vec<String>,
+        /// Label filters to select images by labels.
+        labels: Vec<String>,
+    },
     /// Bring up long-running services defined in CUE configuration.
     Up {
         /// Path to the CUE module or project directory.
@@ -967,6 +980,7 @@ impl CommandExecutor {
             | Command::ToolsDownload
             | Command::ToolsActivate
             | Command::ToolsList
+            | Command::Build { .. }
             | Command::Up { .. }
             | Command::Down { .. }
             | Command::Logs { .. }

--- a/crates/cuenv/src/commands/up.rs
+++ b/crates/cuenv/src/commands/up.rs
@@ -94,9 +94,10 @@ pub async fn execute_up(options: &UpOptions, executor: &CommandExecutor) -> cuen
                 .join(", ")
         ));
 
-        let graph = build_mixed_graph(&project.tasks, &filtered_services, &project.images).map_err(|e| {
-            cuenv_core::Error::execution(format!("Failed to build service graph: {e}"))
-        })?;
+        let graph = build_mixed_graph(&project.tasks, &filtered_services, &project.images)
+            .map_err(|e| {
+                cuenv_core::Error::execution(format!("Failed to build service graph: {e}"))
+            })?;
 
         let session = SessionManager::create(&target_path, &project.name)
             .map_err(|e| cuenv_core::Error::execution(format!("Failed to create session: {e}")))?;

--- a/crates/cuenv/src/commands/up.rs
+++ b/crates/cuenv/src/commands/up.rs
@@ -94,7 +94,7 @@ pub async fn execute_up(options: &UpOptions, executor: &CommandExecutor) -> cuen
                 .join(", ")
         ));
 
-        let graph = build_mixed_graph(&project.tasks, &filtered_services).map_err(|e| {
+        let graph = build_mixed_graph(&project.tasks, &filtered_services, &project.images).map_err(|e| {
             cuenv_core::Error::execution(format!("Failed to build service graph: {e}"))
         })?;
 

--- a/crates/cuenv/src/main.rs
+++ b/crates/cuenv/src/main.rs
@@ -943,6 +943,21 @@ async fn execute_command_safe(
         Command::ToolsList => {
             return commands::tools::execute_tools_list();
         }
+        Command::Build {
+            path,
+            package,
+            names,
+            labels,
+        } => {
+            let options = commands::build::BuildOptions {
+                path: path.clone(),
+                package: package.clone(),
+                names: names.clone(),
+                labels: labels.clone(),
+            };
+            return commands::build::execute_build(&options, executor)
+                .map_err(|e| CliError::eval(format!("Build command failed: {e}")));
+        }
         Command::Up {
             path,
             package,

--- a/crates/cuenv/src/main.rs
+++ b/crates/cuenv/src/main.rs
@@ -144,6 +144,7 @@ const fn requires_async_runtime(cli: &cli::Cli) -> bool {
             // (shell prompt integration requires sub-10ms response time)
             cli::Commands::Version { .. }
             | cli::Commands::Info { .. }
+            | cli::Commands::Build { .. }
             | cli::Commands::Completions { .. }
             | cli::Commands::Changeset { .. }
             | cli::Commands::Secrets { .. }

--- a/crates/cuenv/tests/examples_dag_tests.rs
+++ b/crates/cuenv/tests/examples_dag_tests.rs
@@ -207,6 +207,13 @@ fn get_example_expectations() -> Vec<ExampleExpectations> {
             has_env: false,
             expect_eval_failure: false,
         },
+        ExampleExpectations {
+            name: "container-image",
+            min_task_count: 1, // codegen
+            has_hooks: false,
+            has_env: false,
+            expect_eval_failure: false,
+        },
     ]
 }
 

--- a/crates/services/src/controller.rs
+++ b/crates/services/src/controller.rs
@@ -54,6 +54,7 @@ impl cuenv_task_graph::TaskNodeData for MixedNode {
 pub fn build_mixed_graph(
     tasks: &HashMap<String, cuenv_core::tasks::TaskNode>,
     services: &HashMap<String, Service>,
+    images: &HashMap<String, cuenv_core::manifest::ContainerImage>,
 ) -> crate::Result<TaskGraph<MixedNode>> {
     let mut graph = TaskGraph::new();
 
@@ -69,6 +70,13 @@ pub fn build_mixed_graph(
         let deps: Vec<String> = service.depends_on.iter().map(|d| d.name.clone()).collect();
         let mixed = MixedNode { dependencies: deps };
         graph.add_service(name, mixed)?;
+    }
+
+    // Add image nodes
+    for (name, image) in images {
+        let deps: Vec<String> = image.depends_on.iter().map(|d| d.name.clone()).collect();
+        let mixed = MixedNode { dependencies: deps };
+        graph.add_image(name, mixed)?;
     }
 
     // Resolve dependency edges
@@ -163,6 +171,12 @@ impl ServiceController {
                                 (name, result)
                             });
                         }
+                    }
+                    NodeKind::Image => {
+                        // Image nodes participate in the DAG for dependency
+                        // ordering but are not executed by the service
+                        // controller. Execution backends are future work.
+                        debug!(image = %node.name, "Image node (pre-satisfied)");
                     }
                 }
             }

--- a/crates/task-graph/src/error.rs
+++ b/crates/task-graph/src/error.rs
@@ -33,6 +33,16 @@ pub enum Error {
         /// Reason for the failure.
         reason: String,
     },
+
+    /// A node name is used by different kinds (e.g., task and image both named "api").
+    DuplicateNodeName {
+        /// The colliding name.
+        name: String,
+        /// The kind of the existing node.
+        existing_kind: String,
+        /// The kind of the new node being added.
+        new_kind: String,
+    },
 }
 
 impl fmt::Display for Error {
@@ -54,6 +64,16 @@ impl fmt::Display for Error {
             }
             Self::TopologicalSortFailed { reason } => {
                 write!(f, "Failed to sort tasks topologically: {reason}")
+            }
+            Self::DuplicateNodeName {
+                name,
+                existing_kind,
+                new_kind,
+            } => {
+                write!(
+                    f,
+                    "Node name '{name}' is already used by a {existing_kind}; cannot add as {new_kind}"
+                )
             }
         }
     }

--- a/crates/task-graph/src/graph.rs
+++ b/crates/task-graph/src/graph.rs
@@ -17,6 +17,8 @@ pub enum NodeKind {
     Task,
     /// A long-running service supervised by `cuenv up`.
     Service,
+    /// A container image build managed by `cuenv build`.
+    Image,
 }
 
 impl Default for NodeKind {
@@ -30,6 +32,7 @@ impl std::fmt::Display for NodeKind {
         match self {
             Self::Task => write!(f, "task"),
             Self::Service => write!(f, "service"),
+            Self::Image => write!(f, "image"),
         }
     }
 }
@@ -118,6 +121,32 @@ impl<T: TaskNodeData> TaskGraph<T> {
         let node_index = self.graph.add_node(node);
         self.name_to_node.insert(name.to_string(), node_index);
         debug!("Added service node '{}'", name);
+
+        Ok(node_index)
+    }
+
+    /// Add a single image node to the graph.
+    ///
+    /// Behaves identically to [`add_task`](Self::add_task) but marks the node
+    /// as [`NodeKind::Image`] so the executor can branch on it.
+    ///
+    /// # Errors
+    ///
+    /// Currently infallible, but returns `Result` for API consistency.
+    pub fn add_image(&mut self, name: &str, task: T) -> Result<NodeIndex> {
+        if let Some(&node) = self.name_to_node.get(name) {
+            return Ok(node);
+        }
+
+        let node = GraphNode {
+            name: name.to_string(),
+            task,
+            kind: NodeKind::Image,
+        };
+
+        let node_index = self.graph.add_node(node);
+        self.name_to_node.insert(name.to_string(), node_index);
+        debug!("Added image node '{}'", name);
 
         Ok(node_index)
     }

--- a/crates/task-graph/src/graph.rs
+++ b/crates/task-graph/src/graph.rs
@@ -73,82 +73,63 @@ impl<T: TaskNodeData> TaskGraph<T> {
         }
     }
 
-    /// Add a single task to the graph.
+    /// Add a node to the graph with the given kind.
     ///
-    /// If a task with the same name already exists, returns the existing node index.
-    ///
-    /// # Errors
-    ///
-    /// Currently infallible, but returns `Result` for API consistency.
-    pub fn add_task(&mut self, name: &str, task: T) -> Result<NodeIndex> {
-        // Check if task already exists
-        if let Some(&node) = self.name_to_node.get(name) {
-            return Ok(node);
+    /// If a node with the same name and kind already exists, returns the
+    /// existing node index. If a node with the same name but a *different*
+    /// kind exists, returns a [`DuplicateNodeName`](Error::DuplicateNodeName)
+    /// error.
+    fn add_node_with_kind(&mut self, name: &str, task: T, kind: NodeKind) -> Result<NodeIndex> {
+        if let Some(&existing) = self.name_to_node.get(name) {
+            let existing_kind = self.graph[existing].kind;
+            if existing_kind != kind {
+                return Err(Error::DuplicateNodeName {
+                    name: name.to_string(),
+                    existing_kind: existing_kind.to_string(),
+                    new_kind: kind.to_string(),
+                });
+            }
+            return Ok(existing);
         }
 
         let node = GraphNode {
             name: name.to_string(),
             task,
-            kind: NodeKind::Task,
+            kind,
         };
 
         let node_index = self.graph.add_node(node);
         self.name_to_node.insert(name.to_string(), node_index);
-        debug!("Added task node '{}'", name);
+        debug!("Added {kind} node '{name}'");
 
         Ok(node_index)
+    }
+
+    /// Add a single task to the graph.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if a node with the same name but different kind exists.
+    pub fn add_task(&mut self, name: &str, task: T) -> Result<NodeIndex> {
+        self.add_node_with_kind(name, task, NodeKind::Task)
     }
 
     /// Add a single service node to the graph.
     ///
-    /// Behaves identically to [`add_task`](Self::add_task) but marks the node
-    /// as [`NodeKind::Service`] so the executor can branch on it.
-    ///
     /// # Errors
     ///
-    /// Currently infallible, but returns `Result` for API consistency.
+    /// Returns an error if a node with the same name but different kind exists.
     pub fn add_service(&mut self, name: &str, task: T) -> Result<NodeIndex> {
-        if let Some(&node) = self.name_to_node.get(name) {
-            return Ok(node);
-        }
-
-        let node = GraphNode {
-            name: name.to_string(),
-            task,
-            kind: NodeKind::Service,
-        };
-
-        let node_index = self.graph.add_node(node);
-        self.name_to_node.insert(name.to_string(), node_index);
-        debug!("Added service node '{}'", name);
-
-        Ok(node_index)
+        self.add_node_with_kind(name, task, NodeKind::Service)
     }
 
     /// Add a single image node to the graph.
     ///
-    /// Behaves identically to [`add_task`](Self::add_task) but marks the node
-    /// as [`NodeKind::Image`] so the executor can branch on it.
-    ///
     /// # Errors
     ///
-    /// Currently infallible, but returns `Result` for API consistency.
+    /// Returns an error if a node with the same name but different kind exists.
     pub fn add_image(&mut self, name: &str, task: T) -> Result<NodeIndex> {
-        if let Some(&node) = self.name_to_node.get(name) {
-            return Ok(node);
-        }
-
-        let node = GraphNode {
-            name: name.to_string(),
-            task,
-            kind: NodeKind::Image,
-        };
-
-        let node_index = self.graph.add_node(node);
-        self.name_to_node.insert(name.to_string(), node_index);
-        debug!("Added image node '{}'", name);
-
-        Ok(node_index)
+        self.add_node_with_kind(name, task, NodeKind::Image)
     }
 
     /// Get a mutable reference to a task node by index.

--- a/crates/task-graph/src/graph.rs
+++ b/crates/task-graph/src/graph.rs
@@ -1509,4 +1509,39 @@ mod tests {
         assert_eq!(idx1, idx2);
         assert_eq!(graph.task_count(), 1);
     }
+
+    #[test]
+    fn test_duplicate_node_name_across_kinds() {
+        let mut graph = TaskGraph::new();
+        graph.add_task("api", TestTask::new(&[])).unwrap();
+
+        let err = graph
+            .add_image("api", TestTask::new(&[]))
+            .expect_err("should reject image with same name as task");
+        assert!(
+            matches!(err, Error::DuplicateNodeName { ref name, .. } if name == "api"),
+            "expected DuplicateNodeName error, got: {err}"
+        );
+
+        // Reverse direction: image first, then task
+        let mut graph2 = TaskGraph::new();
+        graph2.add_image("worker", TestTask::new(&[])).unwrap();
+
+        let err2 = graph2
+            .add_service("worker", TestTask::new(&[]))
+            .expect_err("should reject service with same name as image");
+        assert!(
+            matches!(err2, Error::DuplicateNodeName { ref name, .. } if name == "worker"),
+            "expected DuplicateNodeName error, got: {err2}"
+        );
+    }
+
+    #[test]
+    fn test_add_image_deduplication() {
+        let mut graph = TaskGraph::new();
+        let idx1 = graph.add_image("api", TestTask::new(&[])).unwrap();
+        let idx2 = graph.add_image("api", TestTask::new(&[])).unwrap();
+        assert_eq!(idx1, idx2);
+        assert_eq!(graph.task_count(), 1);
+    }
 }

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -118,6 +118,37 @@ Labels are defined in your CUE task configuration and allow grouping related tas
 Use the global `-e` flag to apply environment-specific overrides: `cuenv -e production task build`
 :::
 
+### `cuenv build`
+
+Build container images defined in CUE configuration.
+
+```bash
+cuenv build [NAMES...] [OPTIONS]
+```
+
+**Arguments:**
+
+- `[NAMES]`: Image names to build. If not provided, lists available images.
+
+**Options:**
+
+- `-p, --path <PATH>`: Path to directory containing CUE files. Default: `.`
+- `--package <PACKAGE>`: Name of the CUE package to evaluate. Default: `cuenv`
+- `-l, --label <LABEL>`: Filter images by label (repeatable).
+
+**Examples:**
+
+```bash
+# List all images
+cuenv build
+
+# Build a specific image
+cuenv build api
+
+# Build images matching a label
+cuenv build --label ci
+```
+
 ### `cuenv exec`
 
 Execute a command with CUE environment variables.

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -149,6 +149,106 @@ cuenv build api
 cuenv build --label ci
 ```
 
+### `cuenv up`
+
+Bring up long-running services defined in CUE configuration.
+
+```bash
+cuenv up [SERVICES...] [OPTIONS]
+```
+
+**Arguments:**
+
+- `[SERVICES]`: Service names to bring up. If not provided, starts all services.
+
+**Options:**
+
+- `-p, --path <PATH>`: Path to directory containing CUE files. Default: `.`
+- `--package <PACKAGE>`: Name of the CUE package to evaluate. Default: `cuenv`
+- `-l, --label <LABEL>`: Filter services by label (repeatable).
+
+Services are supervised processes with readiness probes, restart policies, and file watchers. Use `Ctrl+C` to shut down all services.
+
+**Examples:**
+
+```bash
+# Start all services
+cuenv up
+
+# Start specific services
+cuenv up api db
+
+# Start services matching a label
+cuenv up --label backend
+```
+
+### `cuenv down`
+
+Tear down running services.
+
+```bash
+cuenv down [SERVICES...] [OPTIONS]
+```
+
+**Arguments:**
+
+- `[SERVICES]`: Service names to stop. If not provided, stops all services.
+
+**Options:**
+
+- `-p, --path <PATH>`: Path to directory containing CUE files. Default: `.`
+- `--package <PACKAGE>`: Name of the CUE package to evaluate. Default: `cuenv`
+
+### `cuenv ps`
+
+List running services and their status.
+
+```bash
+cuenv ps [OPTIONS]
+```
+
+**Options:**
+
+- `-p, --path <PATH>`: Path to directory containing CUE files. Default: `.`
+- `--package <PACKAGE>`: Name of the CUE package to evaluate. Default: `cuenv`
+- `-o, --output <FORMAT>`: Output format (table, json). Default: `table`
+
+### `cuenv logs`
+
+View service logs.
+
+```bash
+cuenv logs [SERVICES...] [OPTIONS]
+```
+
+**Arguments:**
+
+- `[SERVICES]`: Service names to view logs for. If not provided, shows all.
+
+**Options:**
+
+- `-p, --path <PATH>`: Path to directory containing CUE files. Default: `.`
+- `--package <PACKAGE>`: Name of the CUE package to evaluate. Default: `cuenv`
+- `-f, --follow`: Follow log output (stream in real-time).
+- `-n, --lines <N>`: Number of lines to show. Default: `50`
+
+### `cuenv restart`
+
+Restart one or more services.
+
+```bash
+cuenv restart <SERVICES...> [OPTIONS]
+```
+
+**Arguments:**
+
+- `<SERVICES>`: Service names to restart (required).
+
+**Options:**
+
+- `-p, --path <PATH>`: Path to directory containing CUE files. Default: `.`
+- `--package <PACKAGE>`: Name of the CUE package to evaluate. Default: `cuenv`
+
 ### `cuenv exec`
 
 Execute a command with CUE environment variables.

--- a/docs/src/content/docs/reference/cue-schema.md
+++ b/docs/src/content/docs/reference/cue-schema.md
@@ -352,6 +352,183 @@ tasks: {
 | `task`    | `string`        | Task name in external project |
 | `map`     | `[...#Mapping]` | Output mappings               |
 
+## Services
+
+### #Service
+
+Long-running supervised processes that live alongside tasks on a project. Services must reach a readiness state, are kept alive across the session, restart according to policy, and tear down on `cuenv down`.
+
+```cue
+services: {
+    api: schema.#Service & {
+        command: "go run ./cmd/api"
+        readiness: { kind: "http", url: "http://localhost:8080/health" }
+        restart: { mode: "onFailure" }
+        watch: {
+            paths: ["src/**/*.go"]
+            rebuild: [tasks.build]
+        }
+        description: "API server"
+    }
+    db: schema.#Service & {
+        command: "postgres"
+        args: ["-D", "/var/lib/postgresql/data"]
+        readiness: { kind: "port", port: 5432 }
+    }
+}
+```
+
+**Fields:**
+
+| Field         | Type                              | Required | Description                                   |
+| ------------- | --------------------------------- | -------- | --------------------------------------------- |
+| `command`     | `string`                          | No*      | Command to execute                            |
+| `args`        | `[...string]`                     | No       | Command arguments                             |
+| `script`      | `string`                          | No*      | Inline script (mutually exclusive with command)|
+| `scriptShell` | `#ScriptShell`                    | No       | Shell interpreter for script mode             |
+| `shellOptions`| `#ShellOptions`                   | No       | Shell options (errexit, nounset, etc.)        |
+| `env`         | `{[string]: #EnvironmentVariable}` | No       | Environment variables                         |
+| `dir`         | `string`                          | No       | Working directory override                    |
+| `dependsOn`   | `[...(#TaskNode \| #Service)]`     | No       | Dependencies on tasks or other services       |
+| `labels`      | `[...string]`                     | No       | Labels for discovery                          |
+| `description` | `string`                          | No       | Human-readable description                    |
+| `runtime`     | `#Runtime`                        | No       | Runtime override                              |
+| `readiness`   | `#Readiness`                      | No       | Readiness probe                               |
+| `restart`     | `#RestartPolicy`                  | No       | Restart policy                                |
+| `watch`       | `#Watch`                          | No       | File watcher for restart-on-change            |
+| `logs`        | `#ServiceLogs`                    | No       | Log handling configuration                    |
+| `shutdown`    | `#Shutdown`                       | No       | Shutdown behavior                             |
+| `timeout`     | `string`                          | No       | Hard kill if startup exceeds this duration    |
+
+\* One of `command` or `script` must be provided.
+
+### #Readiness
+
+Readiness probes determine when a service is ready to accept work. Discriminated by the `kind` field.
+
+**Port probe** — TCP connection check:
+
+```cue
+readiness: {
+    kind: "port"
+    port: 8080
+    host: "127.0.0.1"  // default
+}
+```
+
+**HTTP probe** — HTTP request check:
+
+```cue
+readiness: {
+    kind: "http"
+    url: "http://localhost:8080/health"
+    expectStatus: [200]  // default: 2xx
+    method: "GET"        // default
+}
+```
+
+**Log probe** — regex match on stdout/stderr:
+
+```cue
+readiness: {
+    kind: "log"
+    pattern: "Server started on port \\d+"
+    source: "either"  // "stdout", "stderr", or "either" (default)
+}
+```
+
+**Command probe** — exit 0 = ready:
+
+```cue
+readiness: {
+    kind: "command"
+    command: "pg_isready"
+    args: ["-h", "localhost"]
+}
+```
+
+**Delay probe** — fixed sleep (escape hatch):
+
+```cue
+readiness: {
+    kind: "delay"
+    delay: "5s"
+}
+```
+
+All probes (except delay) support common timing fields:
+
+| Field          | Type     | Default  | Description                          |
+| -------------- | -------- | -------- | ------------------------------------ |
+| `interval`     | `string` | `500ms`  | Time between probe attempts          |
+| `timeout`      | `string` | `60s`    | Max time to reach ready              |
+| `initialDelay` | `string` | `0s`     | Initial delay before first attempt   |
+
+### #RestartPolicy
+
+Controls how services restart after exit.
+
+```cue
+restart: {
+    mode: "onFailure"  // never | onFailure | always | unlessStopped
+    backoff: {
+        initial: "1s"
+        max:     "30s"
+        factor:  2.0
+    }
+    maxRestarts: 5
+    window: "60s"
+}
+```
+
+| Field         | Type     | Default       | Description                              |
+| ------------- | -------- | ------------- | ---------------------------------------- |
+| `mode`        | `string` | `onFailure`   | Restart mode                             |
+| `backoff`     | object   | -             | Exponential backoff config               |
+| `maxRestarts` | `int`    | `5`           | Max restarts within sliding window       |
+| `window`      | `string` | `60s`         | Sliding window for restart counting      |
+
+### #Watch
+
+File watcher that triggers service restarts on file changes.
+
+```cue
+watch: {
+    paths: ["src/**/*.go", "go.mod"]
+    ignore: ["*_test.go"]
+    debounce: "200ms"
+    on: "restart"
+    rebuild: [tasks.build]
+}
+```
+
+| Field      | Type            | Default   | Description                                  |
+| ---------- | --------------- | --------- | -------------------------------------------- |
+| `paths`    | `[...string]`   | -         | Glob patterns relative to project root       |
+| `ignore`   | `[...string]`   | -         | Patterns to ignore (gitignore syntax)        |
+| `debounce` | `string`        | `200ms`   | Debounce window for batched changes          |
+| `on`       | `string`        | `restart` | Action on change (`restart`)                 |
+| `rebuild`  | `[...#TaskNode]`| -         | Tasks to re-run before restart               |
+
+### #Shutdown
+
+Controls how services are stopped.
+
+| Field     | Type     | Default   | Description                          |
+| --------- | -------- | --------- | ------------------------------------ |
+| `signal`  | `string` | `SIGTERM` | Signal to send (SIGTERM, SIGINT, SIGHUP, SIGQUIT) |
+| `timeout` | `string` | `10s`     | Grace period before SIGKILL          |
+
+### #ServiceLogs
+
+Log handling configuration for services.
+
+| Field     | Type     | Default        | Description                              |
+| --------- | -------- | -------------- | ---------------------------------------- |
+| `prefix`  | `string` | service name   | Stream prefix in multiplexed output      |
+| `color`   | `string` | auto           | ANSI color hint (red, green, yellow, blue, magenta, cyan, white) |
+| `persist` | `bool`   | `true`         | Persist logs to `.cuenv/run/<project>/logs/` |
+
 ## Container Images
 
 ### #ContainerImage

--- a/docs/src/content/docs/reference/cue-schema.md
+++ b/docs/src/content/docs/reference/cue-schema.md
@@ -25,14 +25,19 @@ tasks: {...}
 
 **Fields:**
 
-| Field        | Type                 | Required | Description                       |
-| ------------ | -------------------- | -------- | --------------------------------- |
-| `config`     | `#Config`            | No       | Global configuration options      |
-| `env`        | `#Env`               | No       | Environment variable definitions  |
-| `hooks`      | `#Hooks`             | No       | Shell hooks for onEnter/onExit    |
-| `name`       | `string`             | Yes      | Project name (used by `#TaskRef`) |
-| `tasks`      | `{[string]: #Tasks}` | No       | Task definitions                  |
-| `workspaces` | `#Workspaces`        | No       | Workspace configuration           |
+| Field        | Type                          | Required | Description                          |
+| ------------ | ----------------------------- | -------- | ------------------------------------ |
+| `config`     | `#Config`                     | No       | Global configuration options         |
+| `env`        | `#Env`                        | No       | Environment variable definitions     |
+| `hooks`      | `#Hooks`                      | No       | Shell hooks for onEnter/onExit       |
+| `name`       | `string`                      | Yes      | Project name (used by `#TaskRef`)    |
+| `tasks`      | `{[string]: #Task}`           | No       | Task definitions                     |
+| `services`   | `{[string]: #Service}`        | No       | Long-running supervised processes    |
+| `images`     | `{[string]: #ContainerImage}` | No       | Container image build definitions    |
+| `ci`         | `#CI`                         | No       | CI pipeline configuration            |
+| `runtime`    | `#Runtime`                    | No       | Default runtime for tasks            |
+| `codegen`    | `#Codegen`                    | No       | Code generation configuration        |
+| `release`    | `#Release`                    | No       | Release management configuration     |
 
 ### #Base
 
@@ -346,6 +351,87 @@ tasks: {
 | `project` | `string`        | Path to external project      |
 | `task`    | `string`        | Task name in external project |
 | `map`     | `[...#Mapping]` | Output mappings               |
+
+## Container Images
+
+### #ContainerImage
+
+Declarative container image builds as first-class project artifacts. Images participate in the task DAG and produce output references (`.ref`, `.digest`) that downstream tasks can consume.
+
+```cue
+images: {
+    api: schema.#ContainerImage & {
+        context:    "."
+        dockerfile: "Dockerfile"
+        tags: ["latest", "v1.0.0"]
+        registry: "ghcr.io/myorg"
+        inputs: ["src/**", "Dockerfile"]
+        description: "API server image"
+    }
+}
+```
+
+**Fields:**
+
+| Field         | Type                                   | Required | Default        | Description                              |
+| ------------- | -------------------------------------- | -------- | -------------- | ---------------------------------------- |
+| `context`     | `string`                               | Yes      | -              | Build context directory                  |
+| `dockerfile`  | `string`                               | No       | `"Dockerfile"` | Dockerfile path relative to context      |
+| `buildArgs`   | `{[string]: string \| #ImageOutputRef}` | No       | -              | Build arguments                          |
+| `target`      | `string`                               | No       | -              | Multi-stage build target                 |
+| `tags`        | `[...string]`                          | No       | -              | Image tags                               |
+| `registry`    | `string`                               | No       | -              | Registry to push to (omit for local)     |
+| `repository`  | `string`                               | No       | -              | Repository name (defaults to image name) |
+| `platform`    | `[...string]`                          | No       | -              | Target platforms for multi-arch builds   |
+| `dependsOn`   | `[...#TaskNode \| #ContainerImage]`     | No       | -              | Dependencies on tasks or other images    |
+| `labels`      | `[...string]`                          | No       | -              | Labels for discovery                     |
+| `inputs`      | `[...#Input]`                          | No       | -              | Input files for cache key derivation     |
+| `description` | `string`                               | No       | -              | Human-readable description               |
+
+#### Output References
+
+Images produce two output references resolved at runtime after the image is built:
+
+| Reference | Description                                      |
+| --------- | ------------------------------------------------ |
+| `.ref`    | Full image reference (e.g., `ghcr.io/myorg/api@sha256:...`) |
+| `.digest` | Content digest of the built image                |
+
+Use these in downstream tasks:
+
+```cue
+tasks: {
+    deploy: schema.#Task & {
+        dependsOn: [images.api]
+        env: IMAGE: images.api.ref
+    }
+}
+```
+
+#### Image Chains
+
+Images can depend on other images for multi-layer builds:
+
+```cue
+images: {
+    base: schema.#ContainerImage & {
+        context: "docker/base"
+    }
+    api: schema.#ContainerImage & {
+        context: "."
+        dependsOn: [images.base]
+        buildArgs: BASE_IMAGE: images.base.ref
+    }
+}
+```
+
+#### CLI
+
+```bash
+cuenv build              # List all images
+cuenv build api          # Build specific image
+cuenv build --label ci   # Build images matching label
+```
 
 ## Hooks
 

--- a/examples/container-image/env.cue
+++ b/examples/container-image/env.cue
@@ -1,0 +1,35 @@
+package examples
+
+import "github.com/cuenv/cuenv/schema"
+
+schema.#Project
+
+name: "container-image-example"
+
+tasks: {
+	codegen: schema.#Task & {
+		command:  "echo"
+		args: ["generating proto files"]
+		hermetic: false
+	}
+}
+
+images: {
+	api: schema.#ContainerImage & {
+		context:    "."
+		dockerfile: "Dockerfile"
+		tags: ["latest", "v1.0.0"]
+		dependsOn: [tasks.codegen]
+		inputs: ["src/**", "Dockerfile"]
+		description: "API server container image"
+	}
+
+	worker: schema.#ContainerImage & {
+		context: "."
+		target:  "worker"
+		tags: ["latest"]
+		labels: ["ci"]
+		platform: ["linux/amd64", "linux/arm64"]
+		description: "Background worker image"
+	}
+}

--- a/schema/core.cue
+++ b/schema/core.cue
@@ -31,6 +31,13 @@ package schema
 		_cuenvPrefix: ""
 		_cuenvSelf:   svcName
 	}
+	// Container image builds — declarative image definitions that
+	// participate in the task DAG and produce output references
+	// (ref, digest) consumable by tasks and other images.
+	images?: [imageName=string]: #ContainerImage & {
+		_cuenvPrefix: ""
+		_cuenvSelf:   imageName
+	}
 	codegen?: #Codegen
 })
 

--- a/schema/images.cue
+++ b/schema/images.cue
@@ -1,0 +1,79 @@
+package schema
+
+// =============================================================================
+// Container Image Output References
+// =============================================================================
+//
+// Images produce `.ref` and `.digest` output references, resolved at runtime
+// after the image is built. These can be consumed by tasks and other images:
+//
+//   tasks: {
+//       deploy: {
+//           dependsOn: [images.api]
+//           env: IMAGE: images.api.ref
+//       }
+//   }
+
+#ImageOutputRef: {
+	cuenvOutputRef: true
+	cuenvImage:     string
+	cuenvOutput:    "ref" | "digest"
+}
+
+// =============================================================================
+// Container Image Build Definition
+// =============================================================================
+//
+// Declarative container image builds as first-class project artifacts.
+// Images participate in the task DAG and can be built via `cuenv build`.
+//
+// Example:
+//   images: {
+//       api: #ContainerImage & {
+//           context: "."
+//           tags: ["latest", "v1.0.0"]
+//           registry: "ghcr.io/myorg"
+//           inputs: ["src/**", "Dockerfile"]
+//       }
+//   }
+
+#ContainerImage: close({
+	_cuenvPrefix: string | *""
+	_cuenvSelf:   string | *""
+	_name: string | *(_cuenvPrefix + _cuenvSelf)
+
+	// Type discriminator
+	type: "image"
+
+	// Runtime output references — resolved after build
+	ref:    #ImageOutputRef & {cuenvImage: _name, cuenvOutput: "ref"}
+	digest: #ImageOutputRef & {cuenvImage: _name, cuenvOutput: "digest"}
+
+	// Build source
+	context!:    string                  // Build context directory
+	dockerfile?: string | *"Dockerfile" // Relative to context
+
+	// Build configuration
+	buildArgs?: [string]: string | #ImageOutputRef
+	target?: string // Multi-stage build target
+
+	// Tagging
+	tags?: [...string]
+
+	// Registry (omit for local-only builds)
+	registry?:   string // e.g., "ghcr.io/cuenv"
+	repository?: string // e.g., "cuenv/api" (defaults to image name)
+
+	// Multi-platform
+	platform?: [...string] // e.g., ["linux/amd64", "linux/arm64"]
+
+	// DAG integration
+	dependsOn?: [...(#TaskNode | #ContainerImage)]
+	labels?: [...string]
+
+	// Cache / inputs
+	inputs?: [...#Input]
+
+	// Human-readable description
+	description?: string
+})

--- a/schema/services.cue
+++ b/schema/services.cue
@@ -39,7 +39,7 @@ package schema
 
 	// Dependencies — may reference tasks OR services. Tasks must complete;
 	// services must become ready before this service starts.
-	dependsOn?: [...(#TaskNode | #Service)]
+	dependsOn?: [...(#TaskNode | #Service | #ContainerImage)]
 
 	// Labels for discovery via #ServiceMatcher (mirrors #TaskMatcher)
 	labels?: [...string]

--- a/schema/tasks.cue
+++ b/schema/tasks.cue
@@ -125,8 +125,8 @@ package schema
 	// declared inputs available. When false, task runs directly in the workspace.
 	hermetic?: bool | *true
 
-	// Dependencies - reference other tasks directly for compile-time validation
-	dependsOn?: [...#TaskNode]
+	// Dependencies - reference other tasks or images for compile-time validation
+	dependsOn?: [...(#TaskNode | #ContainerImage)]
 
 	// Labels for task discovery via #TaskMatcher
 	labels?: [...string]


### PR DESCRIPTION
## Summary

- Adds `#ContainerImage` as a first-class schema type on `#Project`, alongside `tasks` and `services`
- Adds `cuenv build` CLI command for listing and validating image definitions
- Images participate in the task DAG via `NodeKind::Image` and `dependsOn`
- Images produce `.ref` and `.digest` output references for downstream tasks

## DX

```cue
images: {
    api: schema.#ContainerImage & {
        context: "."
        tags: ["latest"]
        dependsOn: [tasks.codegen]
        inputs: ["src/**", "Dockerfile"]
    }
}

tasks: {
    deploy: schema.#Task & {
        dependsOn: [images.api]
        env: IMAGE: images.api.ref  // resolved at runtime
    }
}
```

```bash
cuenv build              # list images
cuenv build api          # build specific image
cuenv build --label ci   # build by label
```

## Scope

This PR lands the **data model and CLI surface**. Execution backends (Dagger, Docker CLI) are follow-up work — `cuenv build <name>` currently validates the config and prints what would be built.

## Files changed

| File | Change |
|------|--------|
| `schema/images.cue` | New — `#ContainerImage` + `#ImageOutputRef` |
| `schema/core.cue` | Add `images?` to `#Project` |
| `crates/core/src/manifest/mod.rs` | `ContainerImage`, `ImageOutputRef` structs + `images` on `Project` |
| `crates/task-graph/src/graph.rs` | `NodeKind::Image` + `add_image()` |
| `crates/services/src/controller.rs` | `images` param on `build_mixed_graph` |
| `crates/cuenv/src/commands/build.rs` | New — build command |
| `crates/cuenv/src/cli.rs` | `Build` CLI variant |
| `crates/cuenv/src/commands/mod.rs` | `Build` command + module |
| `crates/cuenv/src/main.rs` | `Build` dispatch |
| `crates/cuenv/src/commands/up.rs` | Pass `images` to `build_mixed_graph` |
| `examples/container-image/env.cue` | New — example |

## Test plan

- [ ] `nix flake check -L --accept-flake-config` passes (running)
- [ ] Existing examples/tests unaffected (`images` defaults to empty HashMap)
- [ ] New example evaluates cleanly

Closes #364

🤖 Generated with [Claude Code](https://claude.com/claude-code)