### PR TITLE
feat: auto-update homebrew tap on release

### DIFF
--- a/.github/workflows/cuenv-release.yml
+++ b/.github/workflows/cuenv-release.yml
@@ -342,7 +342,6 @@ jobs:
       working-directory: .
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        GH_TOKEN: cuenv:passthrough:HOMEBREW_TAP_TOKEN
         TAG: cuenv:passthrough:GITHUB_REF_NAME
         OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
   docs-deploy:

--- a/.github/workflows/cuenv-release.yml
+++ b/.github/workflows/cuenv-release.yml
@@ -298,6 +298,53 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         TAG: cuenv:passthrough:GITHUB_REF_NAME
         OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+  publish-homebrew:
+    name: publish.homebrew
+    runs-on: namespace-profile-cuenv-linux-x86
+    needs:
+    - build-cuenv-namespace-profile-cuenv-linux-x86
+    - publish-github
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 2
+    - name: Install Nix
+      uses: DeterminateSystems/nix-installer-action@v16
+      with:
+        extra-conf: accept-flake-config = true
+    - name: Setup sccache
+      uses: mozilla-actions/sccache-action@v0.0.9
+      env:
+        RUSTC_WRAPPER: sccache
+        SCCACHE_DIR: ${{ runner.temp }}/sccache
+    - name: Export sccache environment
+      run: echo "SCCACHE_DIR=${{ runner.temp }}/sccache" >> $GITHUB_ENV && echo "RUSTC_WRAPPER=$SCCACHE_PATH" >> $GITHUB_ENV
+    - name: Setup Cachix
+      uses: cachix/cachix-action@v17
+      with:
+        authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+        name: cuenv
+    - name: Build cuenv (nix)
+      run: |-
+        . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+        nix build .#cuenv -L --accept-flake-config
+        echo "$(pwd)/result/bin" >> "$GITHUB_PATH" 2>/dev/null || echo "$(pwd)/result/bin" >> "$BUILDKITE_ENV_FILE" 2>/dev/null || true
+        ./result/bin/cuenv sync ci
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Setup 1Password
+      run: cuenv exec -- cuenv secrets setup onepassword
+      env:
+        OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+    - name: publish.homebrew
+      run: cuenv task publish.homebrew -e production --skip-dependencies
+      working-directory: .
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GH_TOKEN: cuenv:passthrough:HOMEBREW_TAP_TOKEN
+        TAG: cuenv:passthrough:GITHUB_REF_NAME
+        OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
   docs-deploy:
     name: docs.deploy
     runs-on: namespace-profile-cuenv-linux-x86

--- a/env.cue
+++ b/env.cue
@@ -67,6 +67,7 @@ schema.#Project & {
 			CODECOV_TOKEN: schema.#OnePasswordRef & {ref: "op://cuenv-github/codecov/password"}
 			CUE_REGISTRY_TOKEN: schema.#OnePasswordRef & {ref: "op://cuenv-github/cue/password"}
 			VSCE_PAT: schema.#OnePasswordRef & {ref: "op://cuenv-github/visual-studio-code/password"}
+			HOMEBREW_TAP_TOKEN: schema.#OnePasswordRef & {ref: "op://cuenv-github/homebrew-tap/password"}
 		}
 	}
 
@@ -156,6 +157,7 @@ schema.#Project & {
 						}
 					},
 					_t.publish.cue,
+					_t.publish.homebrew,
 					_t.docs.deploy,
 				]
 			}
@@ -405,6 +407,84 @@ schema.#Project & {
 					cue login --token=$CUE_REGISTRY_TOKEN && cue mod publish v$TAG
 					"""]
 				inputs: ["cue.mod/**", "schema/**"]
+			}
+
+			homebrew: schema.#Task & {
+				dependsOn: [_t.publish.github]
+				env: {
+					TAG:      schema.#EnvPassthrough & {name: "GITHUB_REF_NAME"}
+					GH_TOKEN: schema.#EnvPassthrough & {name: "HOMEBREW_TAP_TOKEN"}
+				}
+				command: "bash"
+				args: ["-c", """
+					set -euo pipefail
+
+					TAG=${TAG:-$(git describe --tags --abbrev=0 2>/dev/null || echo "")}
+					if [ -z "$TAG" ]; then
+						echo "Error: No git tag found"
+						exit 1
+					fi
+
+					REPO="cuenv/cuenv"
+					TAP_REPO="cuenv/homebrew-tap"
+					DARWIN_ARM64_URL="https://github.com/${REPO}/releases/download/${TAG}/cuenv-darwin-arm64"
+					LINUX_X64_URL="https://github.com/${REPO}/releases/download/${TAG}/cuenv-linux-x64"
+
+					# Download and checksum
+					TMPDIR=$(mktemp -d)
+					trap 'rm -rf "$TMPDIR"' EXIT
+
+					gh release download "$TAG" -R "$REPO" -p "cuenv-darwin-arm64" -D "$TMPDIR"
+					gh release download "$TAG" -R "$REPO" -p "cuenv-linux-x64" -D "$TMPDIR"
+
+					DARWIN_SHA256=$(shasum -a 256 "$TMPDIR/cuenv-darwin-arm64" | awk '{print $1}')
+					LINUX_SHA256=$(shasum -a 256 "$TMPDIR/cuenv-linux-x64" | awk '{print $1}')
+
+					# Generate formula
+					FORMULA=$(cat <<RUBY
+					class Cuenv < Formula
+					  desc "Modern application build toolchain with typed environments and CUE-powered task orchestration"
+					  homepage "https://github.com/cuenv/cuenv"
+					  version "${TAG}"
+					  license "AGPL-3.0-or-later"
+
+					  on_macos do
+					    on_arm do
+					      url "${DARWIN_ARM64_URL}"
+					      sha256 "${DARWIN_SHA256}"
+					    end
+					  end
+
+					  on_linux do
+					    on_intel do
+					      url "${LINUX_X64_URL}"
+					      sha256 "${LINUX_SHA256}"
+					    end
+					  end
+
+					  def install
+					    bin.install "cuenv"
+					  end
+
+					  test do
+					    assert_match version.to_s, shell_output("#{bin}/cuenv --version")
+					  end
+					end
+					RUBY
+					)
+
+					# Push to tap repo
+					ENCODED=$(echo "$FORMULA" | base64)
+					EXISTING_SHA=$(gh api "repos/${TAP_REPO}/contents/Formula/cuenv.rb" --jq '.sha' 2>/dev/null || echo "")
+
+					if [ -n "$EXISTING_SHA" ]; then
+						gh api -X PUT "repos/${TAP_REPO}/contents/Formula/cuenv.rb" -f message="bump: cuenv ${TAG}" -f content="$ENCODED" -f sha="$EXISTING_SHA" -f branch="main"
+					else
+						gh api -X PUT "repos/${TAP_REPO}/contents/Formula/cuenv.rb" -f message="bump: cuenv ${TAG}" -f content="$ENCODED" -f branch="main"
+					fi
+
+					echo "Homebrew formula updated to ${TAG}"
+					"""]
 			}
 		}
 

--- a/env.cue
+++ b/env.cue
@@ -67,7 +67,6 @@ schema.#Project & {
 			CODECOV_TOKEN: schema.#OnePasswordRef & {ref: "op://cuenv-github/codecov/password"}
 			CUE_REGISTRY_TOKEN: schema.#OnePasswordRef & {ref: "op://cuenv-github/cue/password"}
 			VSCE_PAT: schema.#OnePasswordRef & {ref: "op://cuenv-github/visual-studio-code/password"}
-			HOMEBREW_TAP_TOKEN: schema.#OnePasswordRef & {ref: "op://cuenv-github/homebrew-tap/password"}
 		}
 	}
 
@@ -413,7 +412,7 @@ schema.#Project & {
 				dependsOn: [_t.publish.github]
 				env: {
 					TAG:      schema.#EnvPassthrough & {name: "GITHUB_REF_NAME"}
-					GH_TOKEN: schema.#EnvPassthrough & {name: "HOMEBREW_TAP_TOKEN"}
+					GH_TOKEN: schema.#OnePasswordRef & {ref: "op://cuenv-github/homebrew-tap/password"}
 				}
 				command: "bash"
 				args: ["-c", """
@@ -463,7 +462,14 @@ schema.#Project & {
 					  end
 
 					  def install
-					    bin.install "cuenv"
+					    binary = if OS.mac? && Hardware::CPU.arm?
+					      "cuenv-darwin-arm64"
+					    elsif OS.linux? && Hardware::CPU.intel?
+					      "cuenv-linux-x64"
+					    else
+					      odie "Unsupported platform"
+					    end
+					    bin.install binary => "cuenv"
 					  end
 
 					  test do
@@ -474,7 +480,7 @@ schema.#Project & {
 					)
 
 					# Push to tap repo
-					ENCODED=$(echo "$FORMULA" | base64)
+					ENCODED=$(printf '%s' "$FORMULA" | base64 | tr -d '\n')
 					EXISTING_SHA=$(gh api "repos/${TAP_REPO}/contents/Formula/cuenv.rb" --jq '.sha' 2>/dev/null || echo "")
 
 					if [ -n "$EXISTING_SHA" ]; then


### PR DESCRIPTION
## Summary

- Add `publish.homebrew` task to the release pipeline that automatically updates `cuenv/homebrew-tap` when a release is published
- Formula uses pre-built binaries (darwin-arm64, linux-x64) — no Rust/Go needed to install via Homebrew
- Task depends on `publish.github` to ensure binaries are uploaded before the formula references them

## How it works

1. Downloads release binaries from the GitHub release
2. Computes SHA256 checksums
3. Generates a binary-download Homebrew formula
4. Pushes it to `cuenv/homebrew-tap` via the GitHub API using `HOMEBREW_TAP_TOKEN`

## Setup required

Create a GitHub fine-grained PAT with `Contents: Read and Write` on `cuenv/homebrew-tap` and store it in 1Password at `op://cuenv-github/homebrew-tap-token/password`.

## Test plan

- [x] `cuenv sync ci --check` passes (workflows in sync)
- [ ] Create the `HOMEBREW_TAP_TOKEN` in 1Password
- [ ] Verify on next release that the tap formula is updated automatically