### PR TITLE
fix: resolve task-level environment secrets

### DIFF
--- a/crates/core/src/tasks/backend.rs
+++ b/crates/core/src/tasks/backend.rs
@@ -80,21 +80,11 @@ impl TaskBackend for HostBackend {
             cmd.env(k, v);
         }
 
-        // Apply task-level env vars (plain values and passthrough from host)
-        for (key, value) in &ctx.task.env {
-            if let Some(s) = value.as_str() {
-                if let Some(host_var) = super::output_refs::parse_passthrough(s) {
-                    if let Ok(host_val) = std::env::var(host_var) {
-                        cmd.env(key, host_val);
-                    }
-                } else if !s.starts_with("cuenv:ref:") {
-                    cmd.env(key, s);
-                }
-            } else if let Some(n) = value.as_i64() {
-                cmd.env(key, n.to_string());
-            } else if let Some(b) = value.as_bool() {
-                cmd.env(key, b.to_string());
-            }
+        // Apply task-level env vars, including secrets resolved at execution time.
+        let (task_env, secrets) = super::env::resolve_task_env(ctx.name, &ctx.task.env).await?;
+        cuenv_events::register_secrets(secrets);
+        for (key, value) in task_env {
+            cmd.env(key, value);
         }
 
         // Execute - always capture output for consistent behavior

--- a/crates/core/src/tasks/cache.rs
+++ b/crates/core/src/tasks/cache.rs
@@ -154,20 +154,9 @@ pub async fn build_action(input: BuildActionInput<'_>) -> Result<Option<(Action,
     for (key, value) in &resolved {
         environment_variables.insert(key.clone(), value.clone());
     }
-    for (key, value) in &task.env {
-        if let Some(string_value) = value.as_str() {
-            if let Some(host) = super::output_refs::parse_passthrough(string_value) {
-                if let Ok(host_value) = std::env::var(host) {
-                    environment_variables.insert(key.clone(), host_value);
-                }
-            } else if !string_value.starts_with("cuenv:ref:") {
-                environment_variables.insert(key.clone(), string_value.to_string());
-            }
-        } else if let Some(number) = value.as_i64() {
-            environment_variables.insert(key.clone(), number.to_string());
-        } else if let Some(boolean) = value.as_bool() {
-            environment_variables.insert(key.clone(), boolean.to_string());
-        }
+    let (task_env, _) = super::env::resolve_task_env(task_name, &task.env).await?;
+    for (key, value) in task_env {
+        environment_variables.insert(key, value);
     }
 
     let command_spec = task.command_spec(|command| environment.resolve_command(command))?;

--- a/crates/core/src/tasks/env.rs
+++ b/crates/core/src/tasks/env.rs
@@ -1,0 +1,66 @@
+//! Task-level environment variable handling.
+
+use crate::environment::EnvValue;
+use crate::{Error, Result};
+use serde_json::Value;
+use std::collections::HashMap;
+
+/// Resolve task-level environment values into process environment variables.
+///
+/// Task env values arrive as JSON because they may include runtime-only objects
+/// such as output references, host passthrough markers, or secret refs.
+pub(crate) async fn resolve_task_env(
+    task_name: &str,
+    task_env: &HashMap<String, Value>,
+) -> Result<(HashMap<String, String>, Vec<String>)> {
+    let mut resolved = HashMap::new();
+    let mut secrets = Vec::new();
+
+    for (key, value) in task_env {
+        if let Some(string_value) = value.as_str() {
+            if let Some(host_var) = super::output_refs::parse_passthrough(string_value) {
+                if let Ok(host_value) = std::env::var(host_var) {
+                    resolved.insert(key.clone(), host_value);
+                }
+            } else if !string_value.starts_with("cuenv:ref:") {
+                resolved.insert(key.clone(), string_value.to_string());
+            }
+        } else if let Some(number) = value.as_i64() {
+            resolved.insert(key.clone(), number.to_string());
+        } else if let Some(boolean) = value.as_bool() {
+            resolved.insert(key.clone(), boolean.to_string());
+        } else if let Some(host_var) = passthrough_object_host_var(value, key) {
+            if let Ok(host_value) = std::env::var(host_var) {
+                resolved.insert(key.clone(), host_value);
+            }
+        } else {
+            let env_value: EnvValue = serde_json::from_value(value.clone()).map_err(|e| {
+                Error::configuration(format!(
+                    "Invalid environment value for task '{task_name}' variable '{key}': {e}"
+                ))
+            })?;
+
+            if env_value.is_accessible_by_task(task_name) {
+                let (value, mut resolved_secrets) = env_value.resolve_with_secrets().await?;
+                resolved.insert(key.clone(), value);
+                secrets.append(&mut resolved_secrets);
+            }
+        }
+    }
+
+    Ok((resolved, secrets))
+}
+
+fn passthrough_object_host_var<'a>(value: &'a Value, env_key: &'a str) -> Option<&'a str> {
+    let obj = value.as_object()?;
+    let is_passthrough = obj
+        .get("cuenvPassthrough")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+
+    if !is_passthrough {
+        return None;
+    }
+
+    Some(obj.get("name").and_then(Value::as_str).unwrap_or(env_key))
+}

--- a/crates/core/src/tasks/executor.rs
+++ b/crates/core/src/tasks/executor.rs
@@ -377,24 +377,11 @@ impl TaskExecutor {
             cmd.env(k, v);
         }
 
-        // Apply task-level env vars (plain values and passthrough from host)
-        for (key, value) in &task.env {
-            if let Some(s) = value.as_str() {
-                if let Some(host_var) = super::output_refs::parse_passthrough(s) {
-                    if let Ok(host_val) = std::env::var(host_var) {
-                        cmd.env(key, host_val);
-                    }
-                } else if !s.starts_with("cuenv:ref:") {
-                    // Plain string value — apply directly
-                    cmd.env(key, s);
-                }
-                // Output refs are resolved separately by OutputRefResolver
-            } else if let Some(n) = value.as_i64() {
-                cmd.env(key, n.to_string());
-            } else if let Some(b) = value.as_bool() {
-                cmd.env(key, b.to_string());
-            }
-            // Skip objects (secret refs etc.) — handled by project-level env resolution
+        // Apply task-level env vars, including secrets resolved at execution time.
+        let (task_env, secrets) = super::env::resolve_task_env(name, &task.env).await?;
+        cuenv_events::register_secrets(secrets);
+        for (key, value) in task_env {
+            cmd.env(key, value);
         }
 
         // Force color output even when stdout is piped (for capture mode)
@@ -1062,6 +1049,7 @@ mod tests {
     use cuenv_cas::{LocalActionCache, LocalCas};
     use cuenv_events::{CuenvEventLayer, EventCategory, TaskEvent};
     use cuenv_vcs::WalkHasher;
+    use std::collections::HashMap;
     use tempfile::TempDir;
     use tokio::sync::mpsc;
     use tracing_subscriber::layer::SubscriberExt;
@@ -1127,6 +1115,69 @@ mod tests {
         let result = executor.execute_task("test", &task).await.unwrap();
         assert!(result.success);
         assert!(result.stdout.contains("test_value"));
+    }
+
+    #[tokio::test]
+    async fn test_execute_with_task_secret_environment() {
+        let config = ExecutorConfig {
+            capture_output: OutputCapture::Capture,
+            ..Default::default()
+        };
+        let executor = TaskExecutor::new(config);
+        let task = Task {
+            command: "printenv".to_string(),
+            args: vec!["GH_TOKEN".to_string()],
+            env: HashMap::from([(
+                "GH_TOKEN".to_string(),
+                serde_json::json!({
+                    "resolver": "exec",
+                    "command": "echo",
+                    "args": ["tap-token"]
+                }),
+            )]),
+            description: Some("Print task secret env task".to_string()),
+            ..Default::default()
+        };
+
+        let result = executor.execute_task("test", &task).await.unwrap();
+
+        assert!(result.success);
+        assert_eq!(result.stdout.trim(), "tap-token");
+    }
+
+    #[tokio::test]
+    async fn test_task_secret_gh_token_is_available_with_github_token() {
+        let mut config = ExecutorConfig {
+            capture_output: OutputCapture::Capture,
+            ..Default::default()
+        };
+        config
+            .environment
+            .set("GITHUB_TOKEN".to_string(), "repo-token".to_string());
+        let executor = TaskExecutor::new(config);
+        let task = Task {
+            command: "sh".to_string(),
+            args: vec![
+                "-c".to_string(),
+                r#"test "$GH_TOKEN" = "tap-token" && test "$GITHUB_TOKEN" = "repo-token" && echo ok"#
+                    .to_string(),
+            ],
+            env: HashMap::from([(
+                "GH_TOKEN".to_string(),
+                serde_json::json!({
+                    "resolver": "exec",
+                    "command": "echo",
+                    "args": ["tap-token"]
+                }),
+            )]),
+            description: Some("Verify GitHub CLI token precedence env".to_string()),
+            ..Default::default()
+        };
+
+        let result = executor.execute_task("test", &task).await.unwrap();
+
+        assert!(result.success);
+        assert_eq!(result.stdout.trim(), "ok");
     }
 
     #[tokio::test]

--- a/crates/core/src/tasks/mod.rs
+++ b/crates/core/src/tasks/mod.rs
@@ -12,6 +12,7 @@
 pub mod backend;
 pub mod cache;
 pub mod captures;
+pub(crate) mod env;
 pub mod executor;
 pub mod graph;
 pub mod index;

--- a/docs/src/content/docs/reference/cue-schema.md
+++ b/docs/src/content/docs/reference/cue-schema.md
@@ -141,6 +141,20 @@ env: {
 Use it for CI-provided context such as GitHub Actions actor and ref values. When `name` is omitted,
 cuenv reads the host variable with the same name as the env key.
 
+Task-level `env` accepts the same value forms, including secret refs. For GitHub Actions tasks that
+need to write outside the current repository, prefer a task-local `GH_TOKEN` secret because the
+GitHub CLI reads `GH_TOKEN` before the repository-scoped `GITHUB_TOKEN`:
+
+```cue
+tasks: publish: schema.#Task & {
+    env: GH_TOKEN: schema.#OnePasswordRef & {
+        ref: "op://vault/github-token/password"
+    }
+    command: "gh"
+    args: ["api", "-X", "PUT", "repos/org/other-repo/contents/file"]
+}
+```
+
 ### #Environment
 
 Environment variable naming constraint: must match `^[A-Z][A-Z0-9_]*$` (uppercase with underscores).


### PR DESCRIPTION
## Summary

Fixes task-level environment handling so structured CUE env values, including secret refs like `schema.#OnePasswordRef`, are resolved before task execution instead of being silently skipped.

This addresses the Homebrew publish failure where `publish.homebrew` defined a task-local `GH_TOKEN`, but the executor/backend only propagated primitive env values. As a result, `gh` fell back to the GitHub Actions `GITHUB_TOKEN`, which cannot write to `cuenv/homebrew-tap` and failed with `Resource not accessible by integration`.

## Changes

- Add shared task env resolution for primitive values, passthrough placeholders, and `EnvValue` secrets/interpolations.
- Use the resolver from executor, backend, and cache action environment assembly.
- Register resolved secret values with event redaction.
- Add executor coverage for task-level secret env and `GH_TOKEN` precedence over `GITHUB_TOKEN`.
- Document task-level secret env support and the GitHub Actions `GH_TOKEN` pattern.

## Validation

- `cuenv fmt --fix`
- `cuenv exec -- cargo test -p cuenv-core tasks::executor::tests::test_`
- `cuenv sync ci --check`
- `git diff --check`
- `cuenv exec -- cargo test -p cuenv-core`
- `nix flake check -L --accept-flake-config` is still running locally after the branch push; clippy completed successfully and doctests/nextest were still in progress when this PR was opened.