### PR TITLE
[codex] enforce cuenv module version marker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1231,6 +1231,7 @@ dependencies = [
  "rayon",
  "reqwest 0.13.2",
  "rustls 0.23.39",
+ "semver",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/crates/cuengine/bridge.go
+++ b/crates/cuengine/bridge.go
@@ -22,6 +22,7 @@ import (
 	"cuelang.org/go/cue/cuecontext"
 	"cuelang.org/go/cue/load"
 	"cuelang.org/go/mod/modconfig"
+	"cuelang.org/go/mod/modfile"
 )
 
 const BridgeVersion = "bridge/1"
@@ -98,6 +99,118 @@ func createSuccessResponse(data string) *C.char {
 		return createErrorResponse(ErrorCodeJSONMarshal, msg, nil)
 	}
 	return C.CString(string(responseBytes))
+}
+
+type moduleCustomVersion struct {
+	Version *string `json:"version"`
+}
+
+type moduleFormattedFile struct {
+	Content string `json:"content"`
+}
+
+func readModuleFile(moduleRoot string) (string, []byte, error) {
+	if moduleRoot == "" {
+		return "", nil, fmt.Errorf("module root path cannot be empty")
+	}
+	moduleFile := filepath.Join(moduleRoot, "cue.mod", "module.cue")
+	data, err := os.ReadFile(moduleFile)
+	if err != nil {
+		return moduleFile, nil, fmt.Errorf("failed to read %s: %w", moduleFile, err)
+	}
+	return moduleFile, data, nil
+}
+
+func parseModuleFile(moduleRoot string) (*modfile.File, string, error) {
+	moduleFile, data, err := readModuleFile(moduleRoot)
+	if err != nil {
+		return nil, moduleFile, err
+	}
+	file, err := modfile.ParseNonStrict(data, moduleFile)
+	if err != nil {
+		return nil, moduleFile, err
+	}
+	return file, moduleFile, nil
+}
+
+//export cue_module_custom_version
+func cue_module_custom_version(moduleRootPath *C.char, namespace *C.char) *C.char {
+	var result *C.char
+	defer func() {
+		if r := recover(); r != nil {
+			panicMsg := fmt.Sprintf("Internal panic: %v", r)
+			result = createErrorResponse(ErrorCodePanicRecover, panicMsg, nil)
+		}
+	}()
+
+	moduleRoot := C.GoString(moduleRootPath)
+	customNamespace := C.GoString(namespace)
+	file, moduleFile, err := parseModuleFile(moduleRoot)
+	if err != nil {
+		hint := "Ensure path contains a valid cue.mod/module.cue file"
+		result = createErrorResponse(ErrorCodeInvalidInput, fmt.Sprintf("Failed to parse %s: %v", moduleFile, err), &hint)
+		return result
+	}
+
+	var version *string
+	if file.Custom != nil {
+		if customData, ok := file.Custom[customNamespace]; ok {
+			if rawVersion, ok := customData["version"].(string); ok {
+				version = &rawVersion
+			}
+		}
+	}
+
+	payload, err := json.Marshal(moduleCustomVersion{Version: version})
+	if err != nil {
+		result = createErrorResponse(ErrorCodeJSONMarshal, fmt.Sprintf("Failed to marshal module custom version: %v", err), nil)
+		return result
+	}
+	result = createSuccessResponse(string(payload))
+	return result
+}
+
+//export cue_format_module_with_custom_version
+func cue_format_module_with_custom_version(moduleRootPath *C.char, namespace *C.char, version *C.char) *C.char {
+	var result *C.char
+	defer func() {
+		if r := recover(); r != nil {
+			panicMsg := fmt.Sprintf("Internal panic: %v", r)
+			result = createErrorResponse(ErrorCodePanicRecover, panicMsg, nil)
+		}
+	}()
+
+	moduleRoot := C.GoString(moduleRootPath)
+	customNamespace := C.GoString(namespace)
+	customVersion := C.GoString(version)
+	file, moduleFile, err := parseModuleFile(moduleRoot)
+	if err != nil {
+		hint := "Ensure path contains a valid cue.mod/module.cue file"
+		result = createErrorResponse(ErrorCodeInvalidInput, fmt.Sprintf("Failed to parse %s: %v", moduleFile, err), &hint)
+		return result
+	}
+
+	if file.Custom == nil {
+		file.Custom = make(map[string]map[string]any)
+	}
+	if file.Custom[customNamespace] == nil {
+		file.Custom[customNamespace] = make(map[string]any)
+	}
+	file.Custom[customNamespace]["version"] = customVersion
+
+	formatted, err := modfile.Format(file)
+	if err != nil {
+		result = createErrorResponse(ErrorCodeInvalidInput, fmt.Sprintf("Failed to format %s: %v", moduleFile, err), nil)
+		return result
+	}
+
+	payload, err := json.Marshal(moduleFormattedFile{Content: string(formatted)})
+	if err != nil {
+		result = createErrorResponse(ErrorCodeJSONMarshal, fmt.Sprintf("Failed to marshal formatted module file: %v", err), nil)
+		return result
+	}
+	result = createSuccessResponse(string(payload))
+	return result
 }
 
 // ValueMeta holds source location metadata for a concrete value

--- a/crates/cuengine/src/lib.rs
+++ b/crates/cuengine/src/lib.rs
@@ -21,6 +21,7 @@ pub use validation::Limits;
 // Local type alias for internal use
 use error::CueEngineError as Error;
 
+use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use std::ffi::{CStr, CString};
 use std::marker::PhantomData;
@@ -165,6 +166,15 @@ unsafe extern "C" {
         package_name: *const c_char,
         options_json: *const c_char,
     ) -> *mut c_char;
+    fn cue_module_custom_version(
+        module_root: *const c_char,
+        namespace: *const c_char,
+    ) -> *mut c_char;
+    fn cue_format_module_with_custom_version(
+        module_root: *const c_char,
+        namespace: *const c_char,
+        version: *const c_char,
+    ) -> *mut c_char;
     fn cue_free_string(s: *mut c_char);
     fn cue_bridge_version() -> *mut c_char;
 }
@@ -172,6 +182,20 @@ unsafe extern "C" {
 // Stub FFI for documentation builds - these satisfy the compiler but panic if called
 #[cfg(docsrs)]
 unsafe fn cue_eval_module(_: *const c_char, _: *const c_char, _: *const c_char) -> *mut c_char {
+    panic!("FFI not available in documentation builds")
+}
+
+#[cfg(docsrs)]
+unsafe fn cue_module_custom_version(_: *const c_char, _: *const c_char) -> *mut c_char {
+    panic!("FFI not available in documentation builds")
+}
+
+#[cfg(docsrs)]
+unsafe fn cue_format_module_with_custom_version(
+    _: *const c_char,
+    _: *const c_char,
+    _: *const c_char,
+) -> *mut c_char {
     panic!("FFI not available in documentation builds")
 }
 
@@ -229,6 +253,18 @@ pub struct ModuleResult {
     /// Map of "path/field" to source location (only populated when `with_meta`: true)
     #[serde(default)]
     pub meta: std::collections::HashMap<String, FieldMeta>,
+}
+
+/// Cuenv custom metadata extracted from `cue.mod/module.cue`.
+#[derive(Debug, Deserialize)]
+pub struct ModuleCustomVersion {
+    /// The custom cuenv version marker, if present.
+    pub version: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct FormattedModuleFile {
+    content: String,
 }
 
 /// Evaluates CUE instances in a module and returns results with optional source metadata
@@ -525,6 +561,93 @@ pub fn get_bridge_version() -> Result<String> {
 
     tracing::info!(bridge_version = bridge_version, "Retrieved bridge version");
     Ok(bridge_version)
+}
+
+fn process_bridge_json<T: DeserializeOwned>(
+    json_str: &str,
+    module_root: &Path,
+    function_name: &'static str,
+) -> Result<T> {
+    let envelope = parse_bridge_envelope(json_str).map_err(|err| match err {
+        Error::Ffi { message, .. } => Error::ffi(function_name, message),
+        err => err,
+    })?;
+    if let Some(bridge_error) = envelope.error {
+        return match handle_bridge_error(bridge_error, module_root) {
+            Error::Ffi { message, .. } => Err(Error::ffi(function_name, message)),
+            err => Err(err),
+        };
+    }
+
+    let json_data = envelope
+        .ok
+        .map(|raw| raw.get().to_string())
+        .ok_or_else(|| {
+            Error::ffi(
+                function_name,
+                "Invalid bridge response: missing both 'ok' and 'error' fields".to_string(),
+            )
+        })?;
+
+    serde_json::from_str(&json_data).map_err(|e| {
+        Error::ffi(
+            function_name,
+            format!("Failed to parse bridge response payload: {e}"),
+        )
+    })
+}
+
+/// Read cuenv custom version metadata from `cue.mod/module.cue`.
+///
+/// # Errors
+///
+/// Returns an error if the module file cannot be read or parsed.
+pub fn module_custom_version(module_root: &Path, namespace: &str) -> Result<ModuleCustomVersion> {
+    const FUNCTION_NAME: &str = "cue_module_custom_version";
+    let c_module_root = path_to_cstring(module_root, FUNCTION_NAME, "module root")?;
+    let c_namespace = str_to_cstring(namespace, FUNCTION_NAME, "namespace")?;
+
+    // Safety: cue_module_custom_version takes valid C strings and returns a
+    // heap-allocated C string owned by the caller.
+    let result_ptr =
+        unsafe { cue_module_custom_version(c_module_root.as_ptr(), c_namespace.as_ptr()) };
+    let result = unsafe { CStringPtr::new(result_ptr) };
+    let json_str = extract_ffi_string(result, FUNCTION_NAME)?;
+    process_bridge_json(&json_str, module_root, FUNCTION_NAME)
+}
+
+/// Return a formatted `cue.mod/module.cue` with cuenv custom version metadata set.
+///
+/// This function does not write to disk; callers decide how to handle dry-run
+/// and check modes.
+///
+/// # Errors
+///
+/// Returns an error if the module file cannot be read, parsed, or formatted.
+pub fn format_module_with_custom_version(
+    module_root: &Path,
+    namespace: &str,
+    version: &str,
+) -> Result<String> {
+    const FUNCTION_NAME: &str = "cue_format_module_with_custom_version";
+    let c_module_root = path_to_cstring(module_root, FUNCTION_NAME, "module root")?;
+    let c_namespace = str_to_cstring(namespace, FUNCTION_NAME, "namespace")?;
+    let c_version = str_to_cstring(version, FUNCTION_NAME, "version")?;
+
+    // Safety: cue_format_module_with_custom_version takes valid C strings and
+    // returns a heap-allocated C string owned by the caller.
+    let result_ptr = unsafe {
+        cue_format_module_with_custom_version(
+            c_module_root.as_ptr(),
+            c_namespace.as_ptr(),
+            c_version.as_ptr(),
+        )
+    };
+    let result = unsafe { CStringPtr::new(result_ptr) };
+    let json_str = extract_ffi_string(result, FUNCTION_NAME)?;
+    let formatted: FormattedModuleFile =
+        process_bridge_json(&json_str, module_root, FUNCTION_NAME)?;
+    Ok(formatted.content)
 }
 
 /// Convenience wrapper around `evaluate_module` for single-directory evaluation.

--- a/crates/cuenv/Cargo.toml
+++ b/crates/cuenv/Cargo.toml
@@ -86,6 +86,7 @@ crossterm = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
+semver = { workspace = true }
 indexmap = { version = "2.13", features = ["serde"] }
 thiserror = { workspace = true }
 miette = { workspace = true }

--- a/crates/cuenv/src/commands/handler.rs
+++ b/crates/cuenv/src/commands/handler.rs
@@ -12,7 +12,7 @@ use cuenv_events::{emit_stderr, emit_stdout};
 use crate::cli::{ShellType, StatusFormat};
 use crate::events::Event;
 
-use super::{CommandExecutor, ci, env, exec, export, hooks, sync, task};
+use super::{CommandExecutor, ci, env, exec, export, hooks, module_version, sync, task};
 
 /// Trait for commands with lifecycle events.
 ///
@@ -76,6 +76,13 @@ impl CommandRunner for CommandExecutor {
 // ============================================================================
 // Command Handler Implementations
 // ============================================================================
+
+fn marker_sync_output(marker_sync: &module_version::ModuleVersionSync) -> String {
+    match marker_sync {
+        module_version::ModuleVersionSync::InSync => String::new(),
+        _ => marker_sync.message(),
+    }
+}
 
 /// Handler for `env print` command.
 pub struct EnvPrintHandler {
@@ -608,6 +615,7 @@ impl CommandHandler for SyncHandler {
         };
 
         let path = std::path::Path::new(&self.path);
+        let marker_sync = module_version::sync_marker_for_path(path, &options.mode)?;
         let sync_all = self.scope == SyncScope::Workspace;
         let project_error = |path: &std::path::Path| {
             cuenv_core::Error::configuration(format!(
@@ -656,7 +664,7 @@ impl CommandHandler for SyncHandler {
                     .sync_provider("vcs", path, &self.package, &options, false, executor)
                     .await?
                     .output;
-                return Ok([rules_output, vcs_output]
+                return Ok([marker_sync_output(&marker_sync), rules_output, vcs_output]
                     .into_iter()
                     .filter(|output| !output.is_empty())
                     .collect::<Vec<_>>()
@@ -676,10 +684,14 @@ impl CommandHandler for SyncHandler {
             let result = registry
                 .sync_provider(name, path, &self.package, &options, use_workspace, executor)
                 .await?;
-            return Ok(result.output);
+            return Ok([marker_sync_output(&marker_sync), result.output]
+                .into_iter()
+                .filter(|output| !output.is_empty())
+                .collect::<Vec<_>>()
+                .join("\n\n"));
         }
 
-        run_selected_sync_providers(SelectedSyncProvidersRequest {
+        let provider_output = run_selected_sync_providers(SelectedSyncProvidersRequest {
             registry: &registry,
             provider_names: &["rules", "vcs", "lock", "codegen", "ci", "git-hooks"],
             path,
@@ -688,7 +700,13 @@ impl CommandHandler for SyncHandler {
             scope: &self.scope,
             executor,
         })
-        .await
+        .await?;
+
+        Ok([marker_sync_output(&marker_sync), provider_output]
+            .into_iter()
+            .filter(|output| !output.is_empty())
+            .collect::<Vec<_>>()
+            .join("\n\n"))
     }
 }
 

--- a/crates/cuenv/src/commands/mod.rs
+++ b/crates/cuenv/src/commands/mod.rs
@@ -27,6 +27,8 @@ pub mod info;
 /// View service logs.
 pub mod logs;
 mod module_utils;
+/// CUE module cuenv version compatibility checks.
+pub mod module_version;
 /// List running services and their status.
 pub mod ps;
 /// Release management commands (prepare, version, publish, binaries).
@@ -524,6 +526,7 @@ impl CommandExecutor {
                 target_path.display()
             ))
         })?;
+        module_version::ensure_compatible_module(&module_root)?;
 
         let mut guard = self.workspace_modules.lock().map_err(|_| {
             cuenv_core::Error::configuration("Failed to acquire workspace module cache lock")
@@ -547,6 +550,7 @@ impl CommandExecutor {
                 target_path.display()
             ))
         })?;
+        module_version::ensure_compatible_module(&module_root)?;
 
         let target_rel_path = compute_relative_path(target_path, &module_root);
         let options = ModuleEvalOptions {

--- a/crates/cuenv/src/commands/module_version.rs
+++ b/crates/cuenv/src/commands/module_version.rs
@@ -1,0 +1,243 @@
+//! CUE module cuenv version compatibility checks.
+
+use cuenv_core::Result;
+use cuenv_core::cue::discovery::find_cue_module_root;
+use semver::Version;
+use std::path::{Path, PathBuf};
+
+use super::sync::SyncMode;
+
+const CUENV_MODULE_NAMESPACE: &str = "github.com/cuenv/cuenv";
+
+/// Result of checking or syncing the cuenv version marker in `module.cue`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ModuleVersionSync {
+    /// The marker is already current.
+    InSync,
+    /// The marker is missing and would be added.
+    Missing {
+        /// CLI version that would be written.
+        version: String,
+    },
+    /// The marker exists but would be updated.
+    Stale {
+        /// Version currently recorded in `cue.mod/module.cue`.
+        existing: String,
+        /// CLI version that would be written.
+        current: String,
+    },
+    /// The marker was written.
+    Updated {
+        /// CLI version that was written.
+        version: String,
+    },
+}
+
+impl ModuleVersionSync {
+    /// Human-friendly status message.
+    #[must_use]
+    pub fn message(&self) -> String {
+        match self {
+            Self::InSync => "module.cue cuenv version marker is in sync".to_string(),
+            Self::Missing { version } => {
+                format!("module.cue cuenv version marker missing; would set to {version}")
+            }
+            Self::Stale { existing, current } => {
+                format!("module.cue cuenv version marker is {existing}; would update to {current}")
+            }
+            Self::Updated { version } => {
+                format!("module.cue cuenv version marker updated to {version}")
+            }
+        }
+    }
+}
+
+/// Return the current CLI version.
+#[must_use]
+pub fn cli_version() -> &'static str {
+    env!("CARGO_PKG_VERSION")
+}
+
+/// Find the CUE module root from a command path.
+///
+/// Missing modules return `Ok(None)` so commands that support no-module mode can
+/// continue without a compatibility check.
+///
+/// # Errors
+///
+/// Returns an error if the command path cannot be canonicalized.
+pub fn module_root_for_path(path: impl AsRef<Path>) -> Result<Option<PathBuf>> {
+    let path = path.as_ref();
+    let target_path = path.canonicalize().map_err(|e| cuenv_core::Error::Io {
+        source: e,
+        path: Some(path.to_path_buf().into_boxed_path()),
+        operation: "canonicalize path".to_string(),
+    })?;
+
+    Ok(find_cue_module_root(&target_path))
+}
+
+/// Ensure the module does not require a newer cuenv CLI.
+///
+/// # Errors
+///
+/// Returns an error if the command path cannot be inspected, if the module
+/// marker is invalid, or if the module requires a newer cuenv CLI.
+pub fn ensure_compatible_for_path(path: impl AsRef<Path>) -> Result<()> {
+    if let Some(module_root) = module_root_for_path(path)? {
+        ensure_compatible_module(&module_root)?;
+    }
+    Ok(())
+}
+
+/// Ensure the module root does not require a newer cuenv CLI.
+///
+/// # Errors
+///
+/// Returns an error if the module marker cannot be read, if the marker is
+/// invalid, or if the module requires a newer cuenv CLI.
+pub fn ensure_compatible_module(module_root: &Path) -> Result<()> {
+    let Some(required) = read_module_version(module_root)? else {
+        return Ok(());
+    };
+
+    let required_version = parse_version(&required)?;
+    let current_version = parse_version(cli_version())?;
+    if required_version > current_version {
+        return Err(cuenv_core::Error::configuration(format!(
+            "Project requires cuenv {required}; this CLI is {}. Upgrade cuenv to {required} or newer.",
+            cli_version()
+        )));
+    }
+
+    Ok(())
+}
+
+/// Sync the module's cuenv version marker according to the selected sync mode.
+///
+/// # Errors
+///
+/// Returns an error if no CUE module can be found from the path, if the module
+/// marker is invalid, if the module requires a newer cuenv CLI, or if check or
+/// write mode cannot complete.
+pub fn sync_marker_for_path(path: impl AsRef<Path>, mode: &SyncMode) -> Result<ModuleVersionSync> {
+    let module_root = module_root_for_path(path)?.ok_or_else(|| {
+        cuenv_core::Error::configuration("No CUE module found (looking for cue.mod/)")
+    })?;
+    sync_marker_for_module(&module_root, mode)
+}
+
+/// Sync the module's cuenv version marker according to the selected sync mode.
+///
+/// # Errors
+///
+/// Returns an error if the module marker cannot be read or formatted, if the
+/// marker is invalid, if the module requires a newer cuenv CLI, if `--check`
+/// detects a missing or stale marker, or if writing `module.cue` fails.
+pub fn sync_marker_for_module(module_root: &Path, mode: &SyncMode) -> Result<ModuleVersionSync> {
+    let current = cli_version().to_string();
+    let existing = read_module_version(module_root)?;
+
+    if let Some(existing_version) = existing.as_deref() {
+        let existing_semver = parse_version(existing_version)?;
+        let current_semver = parse_version(&current)?;
+        if existing_semver > current_semver {
+            return Err(cuenv_core::Error::configuration(format!(
+                "Project requires cuenv {existing_version}; this CLI is {current}. Upgrade cuenv to {existing_version} or newer."
+            )));
+        }
+        if versions_equal(existing_version, &current)? {
+            return Ok(ModuleVersionSync::InSync);
+        }
+    }
+
+    match mode {
+        SyncMode::Check => Err(cuenv_core::Error::configuration(
+            marker_status(existing.as_deref(), &current).message(),
+        )),
+        SyncMode::DryRun => Ok(marker_status(existing.as_deref(), &current)),
+        SyncMode::Write => {
+            let formatted = cuengine::format_module_with_custom_version(
+                module_root,
+                CUENV_MODULE_NAMESPACE,
+                &current,
+            )
+            .map_err(super::module_utils::convert_engine_error)?;
+            let module_file = module_root.join("cue.mod").join("module.cue");
+            std::fs::write(&module_file, formatted).map_err(|e| cuenv_core::Error::Io {
+                source: e,
+                path: Some(module_file.into_boxed_path()),
+                operation: "write module.cue".to_string(),
+            })?;
+            Ok(ModuleVersionSync::Updated { version: current })
+        }
+    }
+}
+
+fn marker_status(existing: Option<&str>, current: &str) -> ModuleVersionSync {
+    match existing {
+        Some(existing) => ModuleVersionSync::Stale {
+            existing: existing.to_string(),
+            current: current.to_string(),
+        },
+        None => ModuleVersionSync::Missing {
+            version: current.to_string(),
+        },
+    }
+}
+
+fn read_module_version(module_root: &Path) -> Result<Option<String>> {
+    cuengine::module_custom_version(module_root, CUENV_MODULE_NAMESPACE)
+        .map(|metadata| metadata.version)
+        .map_err(super::module_utils::convert_engine_error)
+}
+
+fn versions_equal(left: &str, right: &str) -> Result<bool> {
+    Ok(parse_version(left)? == parse_version(right)?)
+}
+
+fn parse_version(version: &str) -> Result<Version> {
+    let normalized = version.trim().trim_start_matches('v');
+    Version::parse(normalized).map_err(|e| {
+        cuenv_core::Error::configuration(format!(
+            "Invalid cuenv version marker '{version}' in cue.mod/module.cue: {e}"
+        ))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_version_accepts_optional_v_prefix() {
+        assert_eq!(
+            parse_version("v1.2.3").expect("version"),
+            parse_version("1.2.3").expect("version")
+        );
+    }
+
+    #[test]
+    fn marker_status_reports_missing_and_stale() {
+        assert_eq!(
+            marker_status(None, "1.2.3"),
+            ModuleVersionSync::Missing {
+                version: "1.2.3".to_string()
+            }
+        );
+        assert_eq!(
+            marker_status(Some("1.2.2"), "1.2.3"),
+            ModuleVersionSync::Stale {
+                existing: "1.2.2".to_string(),
+                current: "1.2.3".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn semver_precedence_detects_newer_required_version() {
+        let required = parse_version("1.2.4").expect("required");
+        let current = parse_version("1.2.3").expect("current");
+        assert!(required > current);
+    }
+}

--- a/crates/cuenv/src/main.rs
+++ b/crates/cuenv/src/main.rs
@@ -290,9 +290,69 @@ fn run_sync(cli: cli::Cli) -> i32 {
     }
 }
 
+fn ensure_command_module_compatibility(command: &Command) -> Result<(), CliError> {
+    if !should_precheck_command_module_compatibility(command) {
+        return Ok(());
+    }
+
+    let Some(path) = cue_module_command_path(command) else {
+        return Ok(());
+    };
+    commands::module_version::ensure_compatible_for_path(path).map_err(CliError::from)
+}
+
+fn should_precheck_command_module_compatibility(command: &Command) -> bool {
+    matches!(command, Command::Info { .. })
+}
+
+fn cue_module_command_path(command: &Command) -> Option<&str> {
+    match command {
+        Command::Info { path, .. } => path.as_deref().or(Some(".")),
+        Command::Version { .. }
+        | Command::EnvPrint { .. }
+        | Command::EnvList { .. }
+        | Command::EnvLoad { .. }
+        | Command::EnvStatus { .. }
+        | Command::EnvCheck { .. }
+        | Command::EnvInspect { .. }
+        | Command::Allow { .. }
+        | Command::Deny { .. }
+        | Command::Export { .. }
+        | Command::Exec { .. }
+        | Command::Task { .. }
+        | Command::Sync { .. }
+        | Command::Fmt { .. }
+        | Command::Build { .. }
+        | Command::Up { .. }
+        | Command::Down { .. }
+        | Command::Logs { .. }
+        | Command::Ps { .. }
+        | Command::Restart { .. }
+        | Command::Ci { .. }
+        | Command::ShellInit { .. }
+        | Command::Tui
+        | Command::Web { .. }
+        | Command::Completions { .. }
+        | Command::ChangesetAdd { .. }
+        | Command::ChangesetStatus { .. }
+        | Command::ChangesetFromCommits { .. }
+        | Command::ReleasePrepare { .. }
+        | Command::ReleaseVersion { .. }
+        | Command::ReleasePublish { .. }
+        | Command::ReleaseBinaries { .. }
+        | Command::SecretsSetup { .. }
+        | Command::RuntimeOciActivate
+        | Command::ToolsDownload
+        | Command::ToolsActivate
+        | Command::ToolsList => None,
+    }
+}
+
 /// Execute commands synchronously (no tokio runtime)
 #[allow(clippy::too_many_lines)] // Command dispatcher naturally has many cases
 fn execute_sync_command(command: Command, json_format: cli::OutputFormat) -> Result<(), CliError> {
+    ensure_command_module_compatibility(&command)?;
+
     match command {
         Command::Version { format: _ } => {
             let version_info = commands::version::get_version_info();
@@ -922,6 +982,8 @@ async fn execute_command_safe(
     json_format: cli::OutputFormat,
     executor: &CommandExecutor,
 ) -> Result<(), CliError> {
+    ensure_command_module_compatibility(&command)?;
+
     // Special commands that bypass the executor (they don't fit the event pattern)
     match &command {
         Command::Tui => {

--- a/crates/cuenv/tests/integration_tests.rs
+++ b/crates/cuenv/tests/integration_tests.rs
@@ -123,6 +123,25 @@ env: {
     (temp_dir, path_str)
 }
 
+fn create_git_test_env_with_cuenv_version(
+    version: &str,
+) -> (tempfile::TempDir, String, std::path::PathBuf) {
+    let (temp_dir, path_str) = create_git_test_env();
+    let module_file = temp_dir.path().join("cue.mod/module.cue");
+    fs::write(
+        &module_file,
+        format!(
+            r#"module: "test.example/sync"
+language: version: "v0.14.1"
+custom: "github.com/cuenv/cuenv": version: "{version}"
+"#
+        ),
+    )
+    .expect("Failed to write module.cue with cuenv version");
+
+    (temp_dir, path_str, module_file)
+}
+
 #[test]
 fn test_version_command_basic() {
     let result = run_cuenv_command(&["version"]);
@@ -556,6 +575,91 @@ fn test_sync_command_dry_run_reports_provider_status() {
             );
         }
         Err(e) => panic!("Failed to run cuenv sync --dry-run: {e}"),
+    }
+}
+
+#[test]
+fn test_cue_command_fails_when_module_requires_newer_cuenv() {
+    let (_temp_dir, test_path, _module_file) = create_git_test_env_with_cuenv_version("999.0.0");
+    let result = run_cuenv_command(&["env", "print", "--path", &test_path, "--package", "cuenv"]);
+
+    match result {
+        Ok((stdout, stderr, success)) => {
+            assert!(
+                !success,
+                "Command should fail when module requires newer cuenv"
+            );
+            let combined = format!("{stdout}{stderr}");
+            assert!(combined.contains("Project requires cuenv 999.0.0"));
+            assert!(combined.contains("Upgrade cuenv"));
+        }
+        Err(e) => panic!("Failed to run cuenv env print: {e}"),
+    }
+}
+
+#[test]
+fn test_sync_dry_run_reports_missing_marker_without_writing() {
+    let (temp_dir, test_path) = create_git_test_env();
+    let module_file = temp_dir.path().join("cue.mod/module.cue");
+    let before = fs::read_to_string(&module_file).expect("module.cue");
+    let result = run_cuenv_command(&[
+        "sync",
+        "--path",
+        &test_path,
+        "--package",
+        "cuenv",
+        "--dry-run",
+    ]);
+
+    match result {
+        Ok((stdout, stderr, success)) => {
+            assert!(success, "sync --dry-run should succeed: {stderr}");
+            assert!(stdout.contains("module.cue cuenv version marker missing"));
+            assert!(stdout.contains(EXPECTED_VERSION));
+            let after = fs::read_to_string(&module_file).expect("module.cue after dry-run");
+            assert_eq!(before, after, "dry-run must not update module.cue");
+        }
+        Err(e) => panic!("Failed to run cuenv sync --dry-run: {e}"),
+    }
+}
+
+#[test]
+fn test_sync_check_fails_when_marker_missing() {
+    let (_temp_dir, test_path) = create_git_test_env();
+    let result = run_cuenv_command(&[
+        "sync",
+        "--path",
+        &test_path,
+        "--package",
+        "cuenv",
+        "--check",
+    ]);
+
+    match result {
+        Ok((stdout, stderr, success)) => {
+            assert!(!success, "sync --check should fail for missing marker");
+            let combined = format!("{stdout}{stderr}");
+            assert!(combined.contains("module.cue cuenv version marker missing"));
+        }
+        Err(e) => panic!("Failed to run cuenv sync --check: {e}"),
+    }
+}
+
+#[test]
+fn test_sync_writes_current_marker() {
+    let (temp_dir, test_path) = create_git_test_env();
+    let module_file = temp_dir.path().join("cue.mod/module.cue");
+    let result = run_cuenv_command(&["sync", "--path", &test_path, "--package", "cuenv"]);
+
+    match result {
+        Ok((_stdout, stderr, success)) => {
+            assert!(success, "sync should succeed: {stderr}");
+            let module = fs::read_to_string(&module_file).expect("module.cue after sync");
+            assert!(module.contains("custom: {"));
+            assert!(module.contains("\"github.com/cuenv/cuenv\": {"));
+            assert!(module.contains(&format!("version: \"{EXPECTED_VERSION}\"")));
+        }
+        Err(e) => panic!("Failed to run cuenv sync: {e}"),
     }
 }
 

--- a/cue.mod/module.cue
+++ b/cue.mod/module.cue
@@ -2,7 +2,9 @@ module: "github.com/cuenv/cuenv"
 language: {
 	version: "v0.14.1"
 }
+custom: "github.com/cuenv/cuenv": {
+	version: "0.41.1"
+}
 source: {
 	kind: "git"
 }
-

--- a/docs/src/content/docs/how-to/configure-a-project.md
+++ b/docs/src/content/docs/how-to/configure-a-project.md
@@ -19,6 +19,20 @@ Common organization patterns include:
 - Splitting large sections into files such as `tasks.cue` or directories like `.cuenv/`
 - Importing shared packages from elsewhere in your CUE module (for example `import "github.com/myorg/common"`)
 
+### Module Compatibility
+
+cuenv records the CLI version used to sync a project in `cue.mod/module.cue`:
+
+```cue
+custom: "github.com/cuenv/cuenv": {
+    version: "0.41.1"
+}
+```
+
+This field is tool metadata supported by CUE modules. `language.version` remains the CUE language version and should not be used for cuenv compatibility.
+
+When a cuenv command operates on a CUE module, it checks this marker before evaluation. Missing, older, or equal versions are accepted. If the marker is newer than the running CLI, cuenv exits and asks you to upgrade the CLI. Run `cuenv sync` with a current CLI to add or refresh the marker.
+
 ### Basic Structure
 
 ```cue

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -5,6 +5,16 @@ description: Command-line interface for cuenv
 
 The `cuenv` CLI provides tools for managing environments, executing tasks, and integrating with your shell.
 
+## CUE Module Compatibility
+
+Commands that operate on a CUE module check `cue.mod/module.cue` for cuenv's compatibility marker:
+
+```cue
+custom: "github.com/cuenv/cuenv": version: "0.41.1"
+```
+
+If the marker is newer than the running CLI, the command exits and asks you to upgrade cuenv. Missing markers are accepted for existing projects; `cuenv sync` adds the current CLI version.
+
 ## Global Options
 
 | Option              | Description                                         | Default |
@@ -117,6 +127,21 @@ Labels are defined in your CUE task configuration and allow grouping related tas
 :::tip
 Use the global `-e` flag to apply environment-specific overrides: `cuenv -e production task build`
 :::
+
+### `cuenv sync`
+
+Synchronize generated files and the module's cuenv version marker.
+
+```bash
+cuenv sync [PROVIDER] [OPTIONS]
+```
+
+`cuenv sync` always checks `cue.mod/module.cue` before provider work:
+
+- default write mode adds or updates `custom."github.com/cuenv/cuenv".version`
+- `--check` fails if the marker is missing or stale
+- `--dry-run` reports the marker change without writing
+- a marker newer than the running CLI fails and requires a cuenv upgrade
 
 ### `cuenv build`
 


### PR DESCRIPTION
## Summary

This PR adds a cuenv CLI compatibility marker to CUE modules and keeps it current through `cuenv sync`.

- Reads `custom."github.com/cuenv/cuenv".version` from `cue.mod/module.cue` using new cuengine bridge helpers.
- Rejects CUE-module commands when the module requires a newer cuenv CLI than the binary being run.
- Keeps executor-backed commands validated at the module-evaluation layer, while pre-dispatch validation remains for `cuenv info` to avoid duplicate `module.cue` reads.
- Updates `cuenv sync` so it writes the current CLI version, supports check and dry-run behavior, and reports missing/stale/updated marker states.
- Adds the repository marker to the root `cue.mod/module.cue`.
- Documents the marker in the project configuration guide and CLI reference.
- Adds unit and integration coverage for semver comparison, newer-required failures, sync write/check/dry-run behavior, and sync output.

## Review Follow-Up

- Removed sync output filtering based on the literal `ModuleVersionSync::message()` text; output suppression now keys off the enum state.
- Preserved the computed `cue.mod/module.cue` path on Go bridge read failures so downstream errors include the filename.
- Remapped bridge-envelope parse errors to the active FFI function name for the new module-version bridge calls.
- Resolved the four Copilot review threads after applying the fixes.

## Files Changed

- `cue.mod/module.cue`
- `crates/cuengine/bridge.go`
- `crates/cuengine/src/lib.rs`
- `crates/cuenv/src/commands/module_version.rs`
- `crates/cuenv/src/commands/handler.rs`
- `crates/cuenv/src/commands/mod.rs`
- `crates/cuenv/src/main.rs`
- `crates/cuenv/tests/integration_tests.rs`
- `crates/cuenv/Cargo.toml`
- `Cargo.lock`
- `docs/src/content/docs/how-to/configure-a-project.md`
- `docs/src/content/docs/reference/cli.md`

## Validation

- `cargo fmt --check`
- `cargo check -p cuenv`
- `cargo test -p cuenv --lib module_version`
- `cargo test -p cuenv --test integration_tests test_cue_command_fails_when_module_requires_newer_cuenv`
- `cargo test -p cuenv --test integration_tests test_sync_`
- `nix build .#checks.aarch64-darwin.cuenv-clippy -L --accept-flake-config`
- `nix flake check -L --accept-flake-config`

`nix flake check` passed for `aarch64-darwin`; Nix omitted incompatible systems: `aarch64-linux`, `x86_64-darwin`, and `x86_64-linux`.