### PR TITLE
feat(events): enrich CuenvEvent for groups, cache decisions, queue/retry/skip state

### DIFF
--- a/crates/core/src/tasks/cache.rs
+++ b/crates/core/src/tasks/cache.rs
@@ -16,6 +16,7 @@ use cuenv_cas::{
     Action, ActionCache, ActionResult, Cas, Command, Digest, Directory, DirectoryNode,
     ExecutionMetadata, FileNode, OutputFile, Platform, digest_of,
 };
+use cuenv_events::CacheSkipReason;
 use cuenv_vcs::{HashedInput, VcsHasher};
 use globset::{Glob, GlobSetBuilder};
 use std::collections::BTreeMap;
@@ -23,6 +24,16 @@ use std::path::{Component, Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 use walkdir::WalkDir;
+
+/// Outcome of evaluating a task's cache eligibility.
+#[derive(Debug)]
+pub enum CacheOutcome {
+    /// Task is eligible for caching with the computed action and digest.
+    Eligible(Box<Action>, Digest),
+    /// Task is not eligible; the [`CacheSkipReason`] explains why so renderers
+    /// can surface the reason to the user.
+    Skipped(CacheSkipReason),
+}
 
 /// Bundle of caching infrastructure used by the task executor.
 ///
@@ -89,15 +100,17 @@ pub struct BuildActionInput<'a> {
 
 /// Build the [`Action`] envelope for a task and compute its digest.
 ///
-/// Returns `Ok(None)` when the task is not eligible for caching.
+/// Returns a [`CacheOutcome`] explaining either the resulting action +
+/// digest (eligible) or the structured reason caching was skipped. The
+/// caller is expected to surface the skip reason as a `CacheSkipped` event.
 ///
 /// # Errors
 ///
 /// Propagates failures from task command resolution and canonical encoding.
 ///
-/// Input hashing failures degrade to `Ok(None)` so cache eligibility never
-/// changes whether the task itself is runnable.
-pub async fn build_action(input: BuildActionInput<'_>) -> Result<Option<(Action, Digest)>> {
+/// Input hashing failures degrade to a [`CacheOutcome::Skipped`] so cache
+/// eligibility never changes whether the task itself is runnable.
+pub async fn build_action(input: BuildActionInput<'_>) -> Result<CacheOutcome> {
     let BuildActionInput {
         task,
         task_name,
@@ -110,17 +123,19 @@ pub async fn build_action(input: BuildActionInput<'_>) -> Result<Option<(Action,
 
     if let Some(reason) = &cache.cache_disabled_reason {
         tracing::debug!(task = %task_name, reason, "skipping cache");
-        return Ok(None);
+        return Ok(CacheOutcome::Skipped(CacheSkipReason::Disabled {
+            reason: Some(reason.clone()),
+        }));
     }
 
     let policy = effective_policy(task);
     if !policy.mode.allows_read() && !policy.mode.allows_write() {
         tracing::debug!(task = %task_name, "skipping cache: task cache mode is never");
-        return Ok(None);
+        return Ok(CacheOutcome::Skipped(CacheSkipReason::NeverMode));
     }
 
     if task.inputs.is_empty() {
-        return Ok(None);
+        return Ok(CacheOutcome::Skipped(CacheSkipReason::EmptyInputs));
     }
 
     let mut patterns = Vec::with_capacity(task.inputs.len());
@@ -132,20 +147,20 @@ pub async fn build_action(input: BuildActionInput<'_>) -> Result<Option<(Action,
                 task = %task_name,
                 "skipping cache: task uses non-path input (project/task reference)"
             );
-            return Ok(None);
+            return Ok(CacheOutcome::Skipped(CacheSkipReason::NonPathRef));
         }
     }
 
-    let Some(hashed) = resolve_hashed_inputs(cache, &patterns, project_root, task_name).await?
-    else {
-        return Ok(None);
+    let hashed = match resolve_hashed_inputs(cache, &patterns, project_root, task_name).await? {
+        ResolveOutcome::Resolved(h) => h,
+        ResolveOutcome::Skipped(reason) => return Ok(CacheOutcome::Skipped(reason)),
     };
     if hashed.is_empty() {
         tracing::debug!(
             task = %task_name,
             "skipping cache: declared path inputs resolved to no files"
         );
-        return Ok(None);
+        return Ok(CacheOutcome::Skipped(CacheSkipReason::NoResolvedInputs));
     }
     let input_root_digest = build_input_root_digest(&hashed)?;
 
@@ -154,7 +169,7 @@ pub async fn build_action(input: BuildActionInput<'_>) -> Result<Option<(Action,
             task = %task_name,
             "skipping cache: task defines task-level environment entries resolved at execution time"
         );
-        return Ok(None);
+        return Ok(CacheOutcome::Skipped(CacheSkipReason::RuntimeEnv));
     }
 
     let mut environment_variables = BTreeMap::new();
@@ -196,7 +211,13 @@ pub async fn build_action(input: BuildActionInput<'_>) -> Result<Option<(Action,
     let action_digest = digest_of(&action)
         .map_err(|e| crate::Error::configuration(format!("action digest: {e}")))?;
 
-    Ok(Some((action, action_digest)))
+    Ok(CacheOutcome::Eligible(Box::new(action), action_digest))
+}
+
+/// Internal outcome from input resolution, distinguishing skip reasons.
+enum ResolveOutcome {
+    Resolved(Vec<HashedInput>),
+    Skipped(CacheSkipReason),
 }
 
 async fn resolve_hashed_inputs(
@@ -204,7 +225,7 @@ async fn resolve_hashed_inputs(
     patterns: &[String],
     project_root: &Path,
     task_name: &str,
-) -> Result<Option<Vec<HashedInput>>> {
+) -> Result<ResolveOutcome> {
     let prefixed_patterns =
         match prefix_patterns_for_hasher_root(patterns, project_root, &cache.vcs_hasher_root) {
             Ok(prefixed_patterns) => prefixed_patterns,
@@ -216,7 +237,7 @@ async fn resolve_hashed_inputs(
                     error = %error,
                     "skipping cache: cannot map task inputs to cache hasher root"
                 );
-                return Ok(None);
+                return Ok(ResolveOutcome::Skipped(CacheSkipReason::HasherRootMismatch));
             }
         };
 
@@ -228,7 +249,7 @@ async fn resolve_hashed_inputs(
                 error = %error,
                 "skipping cache: input hashing failed"
             );
-            return Ok(None);
+            return Ok(ResolveOutcome::Skipped(CacheSkipReason::HashFailed));
         }
     };
 
@@ -243,11 +264,11 @@ async fn resolve_hashed_inputs(
                     error = %error,
                     "skipping cache: hashed inputs escaped task project root"
                 );
-                return Ok(None);
+                return Ok(ResolveOutcome::Skipped(CacheSkipReason::HasherRootMismatch));
             }
         };
 
-    Ok(Some(rebased))
+    Ok(ResolveOutcome::Resolved(rebased))
 }
 
 /// Query the action cache for a previous result.
@@ -801,7 +822,10 @@ mod tests {
     }
 
     async fn build_action_for_test(input: BuildActionInput<'_>) -> Option<(Action, Digest)> {
-        build_action(input).await.unwrap()
+        match build_action(input).await.unwrap() {
+            CacheOutcome::Eligible(action, digest) => Some((*action, digest)),
+            CacheOutcome::Skipped(_) => None,
+        }
     }
 
     #[tokio::test]

--- a/crates/core/src/tasks/executor.rs
+++ b/crates/core/src/tasks/executor.rs
@@ -58,6 +58,37 @@ pub struct TaskResult {
 /// Number of lines from stdout/stderr to include when summarizing failures
 pub const TASK_FAILURE_SNIPPET_LINES: usize = 20;
 
+/// Emit a `task.group_completed` event with succeeded/failed/skipped counts
+/// derived from the inner result.
+///
+/// On `Err` the group is reported as failed with all children counted as
+/// failed (we lack per-child results once a sequence/parallel aborts).
+fn emit_group_completion(
+    prefix: &str,
+    started: std::time::Instant,
+    outcome: &Result<Vec<TaskResult>>,
+    total_children: usize,
+) {
+    let duration_ms = u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX);
+    let (success, succeeded, failed, skipped) = match outcome {
+        Ok(results) => {
+            let succeeded = results.iter().filter(|r| r.success).count();
+            let failed = results.iter().filter(|r| !r.success).count();
+            let skipped = total_children.saturating_sub(succeeded + failed);
+            (failed == 0, succeeded, failed, skipped)
+        }
+        Err(_) => (false, 0_usize, total_children, 0_usize),
+    };
+    cuenv_events::emit_task_group_completed!(
+        prefix,
+        success,
+        duration_ms,
+        succeeded,
+        failed,
+        skipped
+    );
+}
+
 /// Task executor configuration
 #[derive(Debug, Clone)]
 pub struct ExecutorConfig {
@@ -158,7 +189,7 @@ impl TaskExecutor {
         let cache_handle: Option<(TaskCacheConfig, cuenv_cas::Digest, PathBuf)> =
             if let Some(cache) = self.config.cache.clone() {
                 let workdir = self.workdir_for_task(task);
-                match super::cache::build_action(BuildActionInput {
+                let outcome = super::cache::build_action(BuildActionInput {
                     task,
                     task_name: name,
                     environment: &self.config.environment,
@@ -171,12 +202,13 @@ impl TaskExecutor {
                         .as_deref()
                         .unwrap_or(&self.config.project_root),
                 })
-                .await?
-                {
-                    Some((_, action_digest)) => {
+                .await?;
+                match outcome {
+                    super::cache::CacheOutcome::Eligible(_, action_digest) => {
                         // Cache lookup. On a hit, short-circuit execution.
                         if let Some(cached) = super::cache::lookup(&cache, &action_digest, task)? {
                             tracing::debug!(task = %name, "action cache hit");
+                            cuenv_events::emit_task_cache_hit!(name, action_digest.to_string());
                             return self.return_cache_hit(CacheHitInput {
                                 name,
                                 task,
@@ -186,9 +218,13 @@ impl TaskExecutor {
                             });
                         }
                         tracing::debug!(task = %name, "action cache miss");
+                        cuenv_events::emit_task_cache_miss!(name);
                         Some((cache, action_digest, workdir))
                     }
-                    None => None,
+                    super::cache::CacheOutcome::Skipped(reason) => {
+                        cuenv_events::emit_task_cache_skipped!(name, reason);
+                        None
+                    }
                 }
             } else {
                 None
@@ -587,9 +623,26 @@ impl TaskExecutor {
         sequence: &[TaskNode],
         all_tasks: &Tasks,
     ) -> Result<Vec<TaskResult>> {
-        if !self.config.capture_output.should_capture() {
+        let emit_lifecycle = !self.config.capture_output.should_capture();
+        if emit_lifecycle {
             cuenv_events::emit_task_group_started!(prefix, true, sequence.len());
         }
+        let started = std::time::Instant::now();
+        let outcome = self
+            .execute_sequential_inner(prefix, sequence, all_tasks)
+            .await;
+        if emit_lifecycle {
+            emit_group_completion(prefix, started, &outcome, sequence.len());
+        }
+        outcome
+    }
+
+    async fn execute_sequential_inner(
+        &self,
+        prefix: &str,
+        sequence: &[TaskNode],
+        all_tasks: &Tasks,
+    ) -> Result<Vec<TaskResult>> {
         let mut results = Vec::new();
         // Track completed step results for output ref resolution within sequences.
         let mut seq_results: std::collections::HashMap<String, TaskResult> =
@@ -639,20 +692,41 @@ impl TaskExecutor {
         group: &TaskGroup,
         all_tasks: &Tasks,
     ) -> Result<Vec<TaskResult>> {
+        let emit_lifecycle = !self.config.capture_output.should_capture();
         // Check for "default" task to override parallel execution
         if let Some(default_task) = group.children.get("default") {
-            if !self.config.capture_output.should_capture() {
+            if emit_lifecycle {
                 cuenv_events::emit_task_group_started!(prefix, true, 1_usize);
             }
+            let started = std::time::Instant::now();
             // Execute only the default task, using the group prefix directly
             // since "default" is implicit when invoking the group name
             let task_name = format!("{}.default", prefix);
-            return self.execute_node(&task_name, default_task, all_tasks).await;
+            let outcome = self.execute_node(&task_name, default_task, all_tasks).await;
+            if emit_lifecycle {
+                emit_group_completion(prefix, started, &outcome, 1);
+            }
+            return outcome;
         }
 
-        if !self.config.capture_output.should_capture() {
+        if emit_lifecycle {
             cuenv_events::emit_task_group_started!(prefix, false, group.children.len());
         }
+        let started = std::time::Instant::now();
+        let total_children = group.children.len();
+        let outcome = self.execute_parallel_inner(prefix, group, all_tasks).await;
+        if emit_lifecycle {
+            emit_group_completion(prefix, started, &outcome, total_children);
+        }
+        outcome
+    }
+
+    async fn execute_parallel_inner(
+        &self,
+        prefix: &str,
+        group: &TaskGroup,
+        all_tasks: &Tasks,
+    ) -> Result<Vec<TaskResult>> {
         let mut join_set = JoinSet::new();
         let all_tasks = Arc::new(all_tasks.clone());
         let mut all_results = Vec::new();

--- a/crates/cuenv/src/tui/mod.rs
+++ b/crates/cuenv/src/tui/mod.rs
@@ -162,18 +162,22 @@ fn format_cuenv_event(event: &CuenvEvent) -> String {
                     name,
                     command,
                     hermetic,
+                    ..
                 } => {
                     format!(
                         "[{timestamp}] {source} TASK {name} started: {command} (hermetic={hermetic})"
                     )
                 }
-                TaskEvent::CacheHit { name, cache_key } => {
+                TaskEvent::CacheHit {
+                    name, cache_key, ..
+                } => {
                     format!("[{timestamp}] {source} CACHE HIT {name} key={cache_key}")
                 }
                 TaskEvent::Output {
                     name,
                     stream,
                     content,
+                    ..
                 } => {
                     format!("[{timestamp}] {source} OUTPUT {name}:{stream:?} {content}")
                 }

--- a/crates/cuenv/src/tui/rich.rs
+++ b/crates/cuenv/src/tui/rich.rs
@@ -279,6 +279,7 @@ impl RichTui {
                 name,
                 stream,
                 content,
+                ..
             } => {
                 let stream_str = match stream {
                     cuenv_events::Stream::Stdout => "stdout",
@@ -304,8 +305,13 @@ impl RichTui {
                     task.exit_code = exit_code;
                 }
             }
-            // These events don't require status updates in the TUI
+            // These events don't require status updates in the TUI yet.
+            // Group/queue/skip/retry visualisation lands in Phase 2/3.
             TaskEvent::CacheMiss { .. }
+            | TaskEvent::CacheSkipped { .. }
+            | TaskEvent::Queued { .. }
+            | TaskEvent::Skipped { .. }
+            | TaskEvent::Retrying { .. }
             | TaskEvent::GroupStarted { .. }
             | TaskEvent::GroupCompleted { .. } => {}
         }

--- a/crates/events/src/event.rs
+++ b/crates/events/src/event.rs
@@ -95,12 +95,18 @@ pub enum EventCategory {
 pub enum TaskEvent {
     /// Task execution started.
     Started {
-        /// Task name.
+        /// Task name (fully qualified, e.g. `group.child`).
         name: String,
         /// Command being executed.
         command: String,
         /// Whether this is a hermetic execution.
         hermetic: bool,
+        /// Parent group prefix, if this task runs inside a group.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        parent_group: Option<String>,
+        /// Kind of node — distinguishes leaf tasks from groups/sequences.
+        #[serde(default)]
+        task_kind: TaskKind,
     },
     /// Task cache hit - using cached result.
     CacheHit {
@@ -108,11 +114,59 @@ pub enum TaskEvent {
         name: String,
         /// Cache key that matched.
         cache_key: String,
+        /// Parent group prefix, if applicable.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        parent_group: Option<String>,
     },
     /// Task cache miss - will execute.
     CacheMiss {
         /// Task name.
         name: String,
+        /// Parent group prefix, if applicable.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        parent_group: Option<String>,
+    },
+    /// Task was not eligible for caching.
+    CacheSkipped {
+        /// Task name.
+        name: String,
+        /// Parent group prefix, if applicable.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        parent_group: Option<String>,
+        /// Why caching was skipped for this task.
+        reason: CacheSkipReason,
+    },
+    /// Task is queued — graph picked it but parallelism cap blocks immediate start.
+    Queued {
+        /// Task name.
+        name: String,
+        /// Parent group prefix, if applicable.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        parent_group: Option<String>,
+        /// Position in the ready queue (zero-based).
+        queue_position: usize,
+    },
+    /// Task is being skipped (e.g. dependency failed under continue-on-error).
+    Skipped {
+        /// Task name.
+        name: String,
+        /// Parent group prefix, if applicable.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        parent_group: Option<String>,
+        /// Why the task is skipped.
+        reason: SkipReason,
+    },
+    /// Task is being retried.
+    Retrying {
+        /// Task name.
+        name: String,
+        /// Parent group prefix, if applicable.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        parent_group: Option<String>,
+        /// Attempt number (1-based).
+        attempt: u32,
+        /// Maximum attempts allowed.
+        max_attempts: u32,
     },
     /// Task produced output.
     Output {
@@ -122,6 +176,9 @@ pub enum TaskEvent {
         stream: Stream,
         /// Output content.
         content: String,
+        /// Parent group prefix, if applicable.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        parent_group: Option<String>,
     },
     /// Task execution completed.
     Completed {
@@ -133,6 +190,9 @@ pub enum TaskEvent {
         exit_code: Option<i32>,
         /// Duration in milliseconds.
         duration_ms: u64,
+        /// Parent group prefix, if applicable.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        parent_group: Option<String>,
     },
     /// Task group execution started.
     GroupStarted {
@@ -142,6 +202,12 @@ pub enum TaskEvent {
         sequential: bool,
         /// Number of tasks in the group.
         task_count: usize,
+        /// Parent group prefix when groups nest.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        parent_group: Option<String>,
+        /// Concurrency cap for the group, if set.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        max_concurrency: Option<u32>,
     },
     /// Task group execution completed.
     GroupCompleted {
@@ -151,7 +217,102 @@ pub enum TaskEvent {
         success: bool,
         /// Duration in milliseconds.
         duration_ms: u64,
+        /// Parent group prefix when groups nest.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        parent_group: Option<String>,
+        /// Number of children that succeeded.
+        #[serde(default)]
+        succeeded: usize,
+        /// Number of children that failed.
+        #[serde(default)]
+        failed: usize,
+        /// Number of children that were skipped.
+        #[serde(default)]
+        skipped: usize,
     },
+}
+
+/// Discriminator for the kind of node a task event refers to.
+///
+/// Leaf tasks default to [`TaskKind::Task`]. Group / sequence containers carry
+/// their own group-level events but child task events keep `TaskKind::Task`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TaskKind {
+    /// A leaf task (default).
+    #[default]
+    Task,
+    /// A parallel group of children.
+    Group,
+    /// A sequential list of children.
+    Sequence,
+}
+
+/// Why a task was not eligible for the action cache.
+///
+/// Renderers surface this so users understand why a task ran instead of
+/// being served from cache.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CacheSkipReason {
+    /// Task declared no `inputs` to hash.
+    EmptyInputs,
+    /// Inputs included a non-path reference (project/task ref).
+    NonPathRef,
+    /// Inputs hashed to zero files after resolution.
+    NoResolvedInputs,
+    /// Task carries task-level env vars resolved at execution time.
+    RuntimeEnv,
+    /// Cache was explicitly disabled for this task.
+    Disabled {
+        /// Optional human-readable reason from the cache config.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        reason: Option<String>,
+    },
+    /// Task cache mode is `never`.
+    NeverMode,
+    /// Inputs could not be mapped onto the cache hasher root.
+    HasherRootMismatch,
+    /// Input hashing itself failed.
+    HashFailed,
+}
+
+impl std::fmt::Display for CacheSkipReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::EmptyInputs => write!(f, "empty inputs"),
+            Self::NonPathRef => write!(f, "non-path input"),
+            Self::NoResolvedInputs => write!(f, "no resolved inputs"),
+            Self::RuntimeEnv => write!(f, "runtime env"),
+            Self::Disabled { reason: Some(r) } => write!(f, "disabled: {r}"),
+            Self::Disabled { reason: None } => write!(f, "disabled"),
+            Self::NeverMode => write!(f, "cache mode never"),
+            Self::HasherRootMismatch => write!(f, "hasher root mismatch"),
+            Self::HashFailed => write!(f, "hashing failed"),
+        }
+    }
+}
+
+/// Why a task was skipped at execution time.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum SkipReason {
+    /// A required dependency failed (under continue-on-error mode).
+    DependencyFailed {
+        /// Name of the failing dependency.
+        dep: String,
+    },
+    /// Task was explicitly disabled.
+    ManuallyDisabled,
+}
+
+impl std::fmt::Display for SkipReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::DependencyFailed { dep } => write!(f, "dependency failed: {dep}"),
+            Self::ManuallyDisabled => write!(f, "manually disabled"),
+        }
+    }
 }
 
 /// Service lifecycle events.
@@ -423,6 +584,8 @@ mod tests {
                 name: "build".to_string(),
                 command: "cargo build".to_string(),
                 hermetic: true,
+                parent_group: None,
+                task_kind: TaskKind::Task,
             }),
         );
 
@@ -432,6 +595,23 @@ mod tests {
 
         let parsed: CuenvEvent = serde_json::from_str(&json).unwrap();
         assert_eq!(parsed.id, event.id);
+    }
+
+    #[test]
+    fn test_started_backcompat_serde_no_parent_group() {
+        let json = r#"{"event":"Started","data":{"name":"build","command":"cargo build","hermetic":true}}"#;
+        let parsed: TaskEvent = serde_json::from_str(json).unwrap();
+        match parsed {
+            TaskEvent::Started {
+                parent_group,
+                task_kind,
+                ..
+            } => {
+                assert_eq!(parent_group, None);
+                assert_eq!(task_kind, TaskKind::Task);
+            }
+            _ => panic!("expected Started"),
+        }
     }
 
     #[test]
@@ -455,19 +635,95 @@ mod tests {
         let event = TaskEvent::CacheHit {
             name: "test".to_string(),
             cache_key: "abc123".to_string(),
+            parent_group: Some("ci".to_string()),
         };
         let json = serde_json::to_string(&event).unwrap();
         assert!(json.contains("CacheHit"));
         assert!(json.contains("abc123"));
+        assert!(json.contains("\"parent_group\":\"ci\""));
     }
 
     #[test]
     fn test_task_event_cache_miss() {
         let event = TaskEvent::CacheMiss {
             name: "test".to_string(),
+            parent_group: None,
         };
         let json = serde_json::to_string(&event).unwrap();
         assert!(json.contains("CacheMiss"));
+        // parent_group: None should not be serialized
+        assert!(!json.contains("parent_group"));
+    }
+
+    #[test]
+    fn test_task_event_cache_skipped() {
+        let event = TaskEvent::CacheSkipped {
+            name: "fmt".to_string(),
+            parent_group: None,
+            reason: CacheSkipReason::EmptyInputs,
+        };
+        let json = serde_json::to_string(&event).unwrap();
+        assert!(json.contains("CacheSkipped"));
+        assert!(json.contains("empty_inputs"));
+
+        let parsed: TaskEvent = serde_json::from_str(&json).unwrap();
+        match parsed {
+            TaskEvent::CacheSkipped { reason, .. } => {
+                assert_eq!(reason, CacheSkipReason::EmptyInputs);
+            }
+            _ => panic!("expected CacheSkipped"),
+        }
+    }
+
+    #[test]
+    fn test_task_event_queued() {
+        let event = TaskEvent::Queued {
+            name: "build".to_string(),
+            parent_group: Some("ci".to_string()),
+            queue_position: 3,
+        };
+        let json = serde_json::to_string(&event).unwrap();
+        assert!(json.contains("Queued"));
+        assert!(json.contains("\"queue_position\":3"));
+    }
+
+    #[test]
+    fn test_task_event_skipped_dependency_failed() {
+        let event = TaskEvent::Skipped {
+            name: "deploy".to_string(),
+            parent_group: None,
+            reason: SkipReason::DependencyFailed {
+                dep: "build".to_string(),
+            },
+        };
+        let json = serde_json::to_string(&event).unwrap();
+        assert!(json.contains("Skipped"));
+        let parsed: TaskEvent = serde_json::from_str(&json).unwrap();
+        match parsed {
+            TaskEvent::Skipped { reason, .. } => {
+                assert_eq!(
+                    reason,
+                    SkipReason::DependencyFailed {
+                        dep: "build".to_string()
+                    }
+                );
+            }
+            _ => panic!("expected Skipped"),
+        }
+    }
+
+    #[test]
+    fn test_task_event_retrying() {
+        let event = TaskEvent::Retrying {
+            name: "flaky".to_string(),
+            parent_group: None,
+            attempt: 2,
+            max_attempts: 3,
+        };
+        let json = serde_json::to_string(&event).unwrap();
+        assert!(json.contains("Retrying"));
+        assert!(json.contains("\"attempt\":2"));
+        assert!(json.contains("\"max_attempts\":3"));
     }
 
     #[test]
@@ -476,6 +732,7 @@ mod tests {
             name: "build".to_string(),
             stream: Stream::Stdout,
             content: "compiling...".to_string(),
+            parent_group: None,
         };
         let json = serde_json::to_string(&event).unwrap();
         assert!(json.contains("Output"));
@@ -489,6 +746,7 @@ mod tests {
             success: true,
             exit_code: Some(0),
             duration_ms: 1500,
+            parent_group: None,
         };
         let json = serde_json::to_string(&event).unwrap();
         assert!(json.contains("Completed"));
@@ -501,10 +759,13 @@ mod tests {
             name: "tests".to_string(),
             sequential: false,
             task_count: 5,
+            parent_group: None,
+            max_concurrency: Some(4),
         };
         let json = serde_json::to_string(&event).unwrap();
         assert!(json.contains("GroupStarted"));
         assert!(json.contains('5'));
+        assert!(json.contains("\"max_concurrency\":4"));
     }
 
     #[test]
@@ -513,9 +774,34 @@ mod tests {
             name: "tests".to_string(),
             success: true,
             duration_ms: 3000,
+            parent_group: None,
+            succeeded: 4,
+            failed: 1,
+            skipped: 0,
         };
         let json = serde_json::to_string(&event).unwrap();
         assert!(json.contains("GroupCompleted"));
+        assert!(json.contains("\"succeeded\":4"));
+        assert!(json.contains("\"failed\":1"));
+    }
+
+    #[test]
+    fn test_cache_skip_reason_display() {
+        assert_eq!(format!("{}", CacheSkipReason::EmptyInputs), "empty inputs");
+        assert_eq!(
+            format!(
+                "{}",
+                CacheSkipReason::Disabled {
+                    reason: Some("hermetic".to_string())
+                }
+            ),
+            "disabled: hermetic"
+        );
+    }
+
+    #[test]
+    fn test_task_kind_default() {
+        assert_eq!(TaskKind::default(), TaskKind::Task);
     }
 
     #[test]
@@ -708,6 +994,7 @@ mod tests {
         let categories = vec![
             EventCategory::Task(TaskEvent::CacheMiss {
                 name: "test".to_string(),
+                parent_group: None,
             }),
             EventCategory::Service(ServiceEvent::Pending {
                 name: "db".to_string(),

--- a/crates/events/src/layer.rs
+++ b/crates/events/src/layer.rs
@@ -11,8 +11,9 @@
 )]
 
 use crate::event::{
-    CiEvent, CommandEvent, CuenvEvent, EventCategory, EventSource, InteractiveEvent, OutputEvent,
-    RestartReason, ServiceEvent, Stream, SystemEvent, TaskEvent,
+    CacheSkipReason, CiEvent, CommandEvent, CuenvEvent, EventCategory, EventSource,
+    InteractiveEvent, OutputEvent, RestartReason, ServiceEvent, SkipReason, Stream, SystemEvent,
+    TaskEvent, TaskKind,
 };
 use crate::metadata::correlation_id;
 use crate::redaction::redact;
@@ -80,6 +81,16 @@ struct CuenvEventVisitor {
     duration_ms: Option<u64>,
     sequential: Option<bool>,
     task_count: Option<usize>,
+    parent_group: Option<String>,
+    task_kind: Option<TaskKind>,
+    cache_skip_reason: Option<CacheSkipReason>,
+    skip_reason: Option<SkipReason>,
+    queue_position: Option<usize>,
+    max_attempts: Option<u32>,
+    max_concurrency: Option<u32>,
+    succeeded_count: Option<usize>,
+    failed_count: Option<usize>,
+    skipped_count: Option<usize>,
 
     // Service event fields
     service_name: Option<String>,
@@ -129,6 +140,16 @@ impl CuenvEventVisitor {
             duration_ms: None,
             sequential: None,
             task_count: None,
+            parent_group: None,
+            task_kind: None,
+            cache_skip_reason: None,
+            skip_reason: None,
+            queue_position: None,
+            max_attempts: None,
+            max_concurrency: None,
+            succeeded_count: None,
+            failed_count: None,
+            skipped_count: None,
             service_name: None,
             after_ms: None,
             attempt: None,
@@ -170,34 +191,67 @@ impl CuenvEventVisitor {
                 name: self.task_name?,
                 command: self.command?,
                 hermetic: self.hermetic.unwrap_or(false),
+                parent_group: self.parent_group,
+                task_kind: self.task_kind.unwrap_or_default(),
             }),
             "task.cache_hit" => EventCategory::Task(TaskEvent::CacheHit {
                 name: self.task_name?,
                 cache_key: self.cache_key?,
+                parent_group: self.parent_group,
             }),
             "task.cache_miss" => EventCategory::Task(TaskEvent::CacheMiss {
                 name: self.task_name?,
+                parent_group: self.parent_group,
+            }),
+            "task.cache_skipped" => EventCategory::Task(TaskEvent::CacheSkipped {
+                name: self.task_name?,
+                parent_group: self.parent_group,
+                reason: self.cache_skip_reason?,
+            }),
+            "task.queued" => EventCategory::Task(TaskEvent::Queued {
+                name: self.task_name?,
+                parent_group: self.parent_group,
+                queue_position: self.queue_position.unwrap_or(0),
+            }),
+            "task.skipped" => EventCategory::Task(TaskEvent::Skipped {
+                name: self.task_name?,
+                parent_group: self.parent_group,
+                reason: self.skip_reason?,
+            }),
+            "task.retrying" => EventCategory::Task(TaskEvent::Retrying {
+                name: self.task_name?,
+                parent_group: self.parent_group,
+                attempt: self.attempt.unwrap_or(1),
+                max_attempts: self.max_attempts.unwrap_or(1),
             }),
             "task.output" => EventCategory::Task(TaskEvent::Output {
                 name: self.task_name?,
                 stream: self.stream.unwrap_or(Stream::Stdout),
                 content: content?,
+                parent_group: self.parent_group,
             }),
             "task.completed" => EventCategory::Task(TaskEvent::Completed {
                 name: self.task_name?,
                 success: self.success?,
                 exit_code: self.exit_code,
                 duration_ms: self.duration_ms.unwrap_or(0),
+                parent_group: self.parent_group,
             }),
             "task.group_started" => EventCategory::Task(TaskEvent::GroupStarted {
                 name: self.task_name?,
                 sequential: self.sequential.unwrap_or(false),
                 task_count: self.task_count.unwrap_or(0),
+                parent_group: self.parent_group,
+                max_concurrency: self.max_concurrency,
             }),
             "task.group_completed" => EventCategory::Task(TaskEvent::GroupCompleted {
                 name: self.task_name?,
                 success: self.success?,
                 duration_ms: self.duration_ms.unwrap_or(0),
+                parent_group: self.parent_group,
+                succeeded: self.succeeded_count.unwrap_or(0),
+                failed: self.failed_count.unwrap_or(0),
+                skipped: self.skipped_count.unwrap_or(0),
             }),
 
             // Service events
@@ -359,6 +413,20 @@ impl Visit for CuenvEventVisitor {
                     _ => None,
                 };
             }
+            "task_kind" => {
+                self.task_kind = match value {
+                    "task" => Some(TaskKind::Task),
+                    "group" => Some(TaskKind::Group),
+                    "sequence" => Some(TaskKind::Sequence),
+                    _ => None,
+                };
+            }
+            "cache_skip_reason" => {
+                self.cache_skip_reason = serde_json::from_str(value).ok();
+            }
+            "skip_reason" => {
+                self.skip_reason = serde_json::from_str(value).ok();
+            }
             _ => {}
         }
     }
@@ -369,8 +437,14 @@ impl Visit for CuenvEventVisitor {
             "duration_ms" => self.duration_ms = Some(value as u64),
             "after_ms" => self.after_ms = Some(value as u64),
             "attempt" => self.attempt = Some(value as u32),
+            "max_attempts" => self.max_attempts = Some(value as u32),
             "count" => self.count = Some(value as usize),
             "task_count" => self.task_count = Some(value as usize),
+            "queue_position" => self.queue_position = Some(value as usize),
+            "max_concurrency" => self.max_concurrency = Some(value as u32),
+            "succeeded" => self.succeeded_count = Some(value as usize),
+            "failed_count" => self.failed_count = Some(value as usize),
+            "skipped_count" => self.skipped_count = Some(value as usize),
             "elapsed_secs" => self.elapsed_secs = Some(value as u64),
             _ => {}
         }
@@ -381,8 +455,14 @@ impl Visit for CuenvEventVisitor {
             "duration_ms" => self.duration_ms = Some(value),
             "after_ms" => self.after_ms = Some(value),
             "attempt" => self.attempt = Some(value as u32),
+            "max_attempts" => self.max_attempts = Some(value as u32),
             "count" => self.count = Some(value as usize),
             "task_count" => self.task_count = Some(value as usize),
+            "queue_position" => self.queue_position = Some(value as usize),
+            "max_concurrency" => self.max_concurrency = Some(value as u32),
+            "succeeded" => self.succeeded_count = Some(value as usize),
+            "failed_count" => self.failed_count = Some(value as usize),
+            "skipped_count" => self.skipped_count = Some(value as usize),
             "elapsed_secs" => self.elapsed_secs = Some(value),
             _ => {}
         }
@@ -427,7 +507,7 @@ impl Visit for CuenvEventVisitor {
             // When tracing uses Display formatting (%), it wraps values in a DisplayValue
             // which then gets passed to record_debug instead of record_str
             "event_type" | "task_name" | "service_name" | "name" | "command" | "cmd"
-            | "content" | "cache_key" | "stream" | "error" | "reason" => {
+            | "content" | "cache_key" | "stream" | "error" | "reason" | "task_kind" => {
                 // Remove surrounding quotes if present (debug format adds them for strings)
                 let cleaned = value_str.trim_matches('"');
                 match field.name() {
@@ -446,8 +526,32 @@ impl Visit for CuenvEventVisitor {
                             _ => None,
                         };
                     }
+                    "task_kind" => {
+                        self.task_kind = match cleaned {
+                            "task" => Some(TaskKind::Task),
+                            "group" => Some(TaskKind::Group),
+                            "sequence" => Some(TaskKind::Sequence),
+                            _ => None,
+                        };
+                    }
                     _ => {}
                 }
+            }
+            // The cache_skip_reason and skip_reason fields carry JSON-encoded
+            // enum values via Display formatting (%). When the JSON itself is
+            // already-quoted (e.g. unit variant `"empty_inputs"`) we must not
+            // strip the quotes — serde_json needs them to deserialize.
+            "cache_skip_reason" => {
+                let cleaned = value_str.trim_matches('"');
+                self.cache_skip_reason = serde_json::from_str(cleaned)
+                    .ok()
+                    .or_else(|| serde_json::from_str(&value_str).ok());
+            }
+            "skip_reason" => {
+                let cleaned = value_str.trim_matches('"');
+                self.skip_reason = serde_json::from_str(cleaned)
+                    .ok()
+                    .or_else(|| serde_json::from_str(&value_str).ok());
             }
             // Handle exit_code which uses Debug formatting (?exit_code)
             // Can be "Some(0)", "None", or just "0" depending on context
@@ -466,9 +570,37 @@ impl Visit for CuenvEventVisitor {
                     }
                 }
             }
+            // parent_group uses Debug (?parent_group) since the macro accepts
+            // Option<impl Display> and that doesn't itself impl Display.
+            // Format is `Some("ci")`, `None`, or `Some(ci)` depending on
+            // whether the inner value impls Debug as a quoted string.
+            "parent_group" => {
+                self.parent_group = parse_optional_debug_str(&value_str);
+            }
+            // max_concurrency uses ?max_concurrency (Option<u32>).
+            "max_concurrency" => {
+                if let Some(inner) = value_str
+                    .strip_prefix("Some(")
+                    .and_then(|s| s.strip_suffix(')'))
+                    && let Ok(n) = inner.parse::<u32>()
+                {
+                    self.max_concurrency = Some(n);
+                }
+            }
             _ => {}
         }
     }
+}
+
+/// Parse a Rust-`Debug`-formatted `Option<impl Debug>` containing a string.
+///
+/// Handles `Some("foo")`, `Some(foo)`, and `None`.
+fn parse_optional_debug_str(value: &str) -> Option<String> {
+    if value == "None" {
+        return None;
+    }
+    let inner = value.strip_prefix("Some(")?.strip_suffix(')')?;
+    Some(inner.trim_matches('"').to_string())
 }
 
 #[cfg(test)]
@@ -547,12 +679,77 @@ mod tests {
                 name,
                 command,
                 hermetic,
+                ..
             }) => {
                 assert_eq!(name, "build");
                 assert_eq!(command, "cargo build");
                 assert!(hermetic);
             }
             _ => panic!("Expected task started event"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_layer_extracts_parent_group_and_task_kind() {
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let layer = CuenvEventLayer::new(tx);
+        let subscriber = tracing_subscriber::registry().with(layer);
+
+        tracing::subscriber::with_default(subscriber, || {
+            let parent: Option<&str> = Some("ci");
+            tracing::info!(
+                target: "cuenv::task",
+                event_type = "task.started",
+                task_name = "ci.build",
+                command = "cargo build",
+                hermetic = true,
+                parent_group = ?parent,
+                task_kind = "task",
+                "Task started in group"
+            );
+        });
+
+        let event = rx.recv().await.unwrap();
+        match event.category {
+            EventCategory::Task(TaskEvent::Started {
+                name,
+                parent_group,
+                task_kind,
+                ..
+            }) => {
+                assert_eq!(name, "ci.build");
+                assert_eq!(parent_group.as_deref(), Some("ci"));
+                assert_eq!(task_kind, TaskKind::Task);
+            }
+            other => panic!("Expected task started event, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_layer_extracts_cache_skipped() {
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let layer = CuenvEventLayer::new(tx);
+        let subscriber = tracing_subscriber::registry().with(layer);
+
+        tracing::subscriber::with_default(subscriber, || {
+            let reason = CacheSkipReason::EmptyInputs;
+            let encoded = serde_json::to_string(&reason).unwrap();
+            tracing::info!(
+                target: "cuenv::task",
+                event_type = "task.cache_skipped",
+                task_name = "fmt",
+                cache_skip_reason = %encoded,
+                "skipped"
+            );
+        });
+
+        let event = rx.recv().await.unwrap();
+        match event.category {
+            EventCategory::Task(TaskEvent::CacheSkipped { name, reason, .. }) => {
+                assert_eq!(name, "fmt");
+                assert_eq!(reason, CacheSkipReason::EmptyInputs);
+            }
+            other => panic!("Expected cache skipped event, got {other:?}"),
         }
     }
 }

--- a/crates/events/src/lib.rs
+++ b/crates/events/src/lib.rs
@@ -46,8 +46,9 @@ pub mod renderers;
 // Re-exports for convenience
 pub use bus::{EventBus, EventReceiver, EventSender, SendError};
 pub use event::{
-    CiEvent, CommandEvent, CuenvEvent, EventCategory, EventSource, InteractiveEvent, OutputEvent,
-    RestartReason, ServiceEvent, Stream, SystemEvent, TaskEvent,
+    CacheSkipReason, CiEvent, CommandEvent, CuenvEvent, EventCategory, EventSource,
+    InteractiveEvent, OutputEvent, RestartReason, ServiceEvent, SkipReason, Stream, SystemEvent,
+    TaskEvent, TaskKind,
 };
 pub use layer::CuenvEventLayer;
 pub use metadata::{MetadataContext, correlation_id, set_correlation_id};
@@ -60,10 +61,12 @@ pub use renderers::{CliRenderer, JsonRenderer};
 
 /// Emit a task started event.
 ///
-/// # Example
-/// ```rust,ignore
-/// emit_task_started!("build", "cargo build", true);
-/// ```
+/// Two forms are supported:
+/// - `emit_task_started!(name, command, hermetic)` — leaf task, no group.
+/// - `emit_task_started!(name, command, hermetic, parent_group, task_kind)`
+///   — leaf or group task, optionally inside a parent group.
+///   `parent_group` is `Option<&str>` (or anything `Display`); `task_kind`
+///   is a `&'static str` matching `TaskKind` (`"task"`, `"group"`, `"sequence"`).
 #[macro_export]
 macro_rules! emit_task_started {
     ($name:expr, $command:expr, $hermetic:expr) => {
@@ -75,14 +78,24 @@ macro_rules! emit_task_started {
             hermetic = $hermetic,
         )
     };
+    ($name:expr, $command:expr, $hermetic:expr, $parent_group:expr, $task_kind:expr) => {
+        ::tracing::info!(
+            target: "cuenv::task",
+            event_type = "task.started",
+            task_name = %$name,
+            command = %$command,
+            hermetic = $hermetic,
+            parent_group = ?$parent_group,
+            task_kind = $task_kind,
+        )
+    };
 }
 
 /// Emit a task cache hit event.
 ///
-/// # Example
-/// ```rust,ignore
-/// emit_task_cache_hit!("build", "abc123");
-/// ```
+/// Forms:
+/// - `emit_task_cache_hit!(name, cache_key)`
+/// - `emit_task_cache_hit!(name, cache_key, parent_group)`
 #[macro_export]
 macro_rules! emit_task_cache_hit {
     ($name:expr, $cache_key:expr) => {
@@ -93,9 +106,22 @@ macro_rules! emit_task_cache_hit {
             cache_key = %$cache_key,
         )
     };
+    ($name:expr, $cache_key:expr, $parent_group:expr) => {
+        ::tracing::info!(
+            target: "cuenv::task",
+            event_type = "task.cache_hit",
+            task_name = %$name,
+            cache_key = %$cache_key,
+            parent_group = ?$parent_group,
+        )
+    };
 }
 
 /// Emit a task cache miss event.
+///
+/// Forms:
+/// - `emit_task_cache_miss!(name)`
+/// - `emit_task_cache_miss!(name, parent_group)`
 #[macro_export]
 macro_rules! emit_task_cache_miss {
     ($name:expr) => {
@@ -105,14 +131,131 @@ macro_rules! emit_task_cache_miss {
             task_name = %$name,
         )
     };
+    ($name:expr, $parent_group:expr) => {
+        ::tracing::info!(
+            target: "cuenv::task",
+            event_type = "task.cache_miss",
+            task_name = %$name,
+            parent_group = ?$parent_group,
+        )
+    };
+}
+
+/// Emit a task cache skipped event with a structured reason.
+///
+/// `reason` should be a [`crate::CacheSkipReason`].
+///
+/// Forms:
+/// - `emit_task_cache_skipped!(name, reason)`
+/// - `emit_task_cache_skipped!(name, reason, parent_group)`
+#[macro_export]
+macro_rules! emit_task_cache_skipped {
+    ($name:expr, $reason:expr) => {
+        ::tracing::info!(
+            target: "cuenv::task",
+            event_type = "task.cache_skipped",
+            task_name = %$name,
+            cache_skip_reason = %$crate::__macro_helpers::encode_cache_skip_reason(&$reason),
+        )
+    };
+    ($name:expr, $reason:expr, $parent_group:expr) => {
+        ::tracing::info!(
+            target: "cuenv::task",
+            event_type = "task.cache_skipped",
+            task_name = %$name,
+            cache_skip_reason = %$crate::__macro_helpers::encode_cache_skip_reason(&$reason),
+            parent_group = ?$parent_group,
+        )
+    };
+}
+
+/// Emit a task queued event (graph picked task but parallelism cap blocks start).
+///
+/// Forms:
+/// - `emit_task_queued!(name, queue_position)`
+/// - `emit_task_queued!(name, queue_position, parent_group)`
+#[macro_export]
+macro_rules! emit_task_queued {
+    ($name:expr, $queue_position:expr) => {
+        ::tracing::info!(
+            target: "cuenv::task",
+            event_type = "task.queued",
+            task_name = %$name,
+            queue_position = $queue_position,
+        )
+    };
+    ($name:expr, $queue_position:expr, $parent_group:expr) => {
+        ::tracing::info!(
+            target: "cuenv::task",
+            event_type = "task.queued",
+            task_name = %$name,
+            queue_position = $queue_position,
+            parent_group = ?$parent_group,
+        )
+    };
+}
+
+/// Emit a task skipped event with a structured reason.
+///
+/// `reason` should be a [`crate::SkipReason`].
+///
+/// Forms:
+/// - `emit_task_skipped!(name, reason)`
+/// - `emit_task_skipped!(name, reason, parent_group)`
+#[macro_export]
+macro_rules! emit_task_skipped {
+    ($name:expr, $reason:expr) => {
+        ::tracing::info!(
+            target: "cuenv::task",
+            event_type = "task.skipped",
+            task_name = %$name,
+            skip_reason = %$crate::__macro_helpers::encode_skip_reason(&$reason),
+        )
+    };
+    ($name:expr, $reason:expr, $parent_group:expr) => {
+        ::tracing::info!(
+            target: "cuenv::task",
+            event_type = "task.skipped",
+            task_name = %$name,
+            skip_reason = %$crate::__macro_helpers::encode_skip_reason(&$reason),
+            parent_group = ?$parent_group,
+        )
+    };
+}
+
+/// Emit a task retrying event.
+///
+/// Forms:
+/// - `emit_task_retrying!(name, attempt, max_attempts)`
+/// - `emit_task_retrying!(name, attempt, max_attempts, parent_group)`
+#[macro_export]
+macro_rules! emit_task_retrying {
+    ($name:expr, $attempt:expr, $max_attempts:expr) => {
+        ::tracing::info!(
+            target: "cuenv::task",
+            event_type = "task.retrying",
+            task_name = %$name,
+            attempt = $attempt,
+            max_attempts = $max_attempts,
+        )
+    };
+    ($name:expr, $attempt:expr, $max_attempts:expr, $parent_group:expr) => {
+        ::tracing::info!(
+            target: "cuenv::task",
+            event_type = "task.retrying",
+            task_name = %$name,
+            attempt = $attempt,
+            max_attempts = $max_attempts,
+            parent_group = ?$parent_group,
+        )
+    };
 }
 
 /// Emit a task output event.
 ///
-/// # Example
-/// ```rust,ignore
-/// emit_task_output!("build", "stdout", "Compiling...");
-/// ```
+/// Forms:
+/// - `emit_task_output!(name, stream, content)`
+/// - `emit_task_output!(name, stream, content, parent_group)`
 #[macro_export]
 macro_rules! emit_task_output {
     ($name:expr, $stream:expr, $content:expr) => {
@@ -124,14 +267,23 @@ macro_rules! emit_task_output {
             content = %$content,
         )
     };
+    ($name:expr, $stream:expr, $content:expr, $parent_group:expr) => {
+        ::tracing::info!(
+            target: "cuenv::task",
+            event_type = "task.output",
+            task_name = %$name,
+            stream = $stream,
+            content = %$content,
+            parent_group = ?$parent_group,
+        )
+    };
 }
 
 /// Emit a task completed event.
 ///
-/// # Example
-/// ```rust,ignore
-/// emit_task_completed!("build", true, Some(0), 1234);
-/// ```
+/// Forms:
+/// - `emit_task_completed!(name, success, exit_code, duration_ms)`
+/// - `emit_task_completed!(name, success, exit_code, duration_ms, parent_group)`
 #[macro_export]
 macro_rules! emit_task_completed {
     ($name:expr, $success:expr, $exit_code:expr, $duration_ms:expr) => {
@@ -144,9 +296,24 @@ macro_rules! emit_task_completed {
             duration_ms = $duration_ms,
         )
     };
+    ($name:expr, $success:expr, $exit_code:expr, $duration_ms:expr, $parent_group:expr) => {
+        ::tracing::info!(
+            target: "cuenv::task",
+            event_type = "task.completed",
+            task_name = %$name,
+            success = $success,
+            exit_code = ?$exit_code,
+            duration_ms = $duration_ms,
+            parent_group = ?$parent_group,
+        )
+    };
 }
 
 /// Emit a task group started event.
+///
+/// Forms:
+/// - `emit_task_group_started!(name, sequential, task_count)`
+/// - `emit_task_group_started!(name, sequential, task_count, parent_group, max_concurrency)`
 #[macro_export]
 macro_rules! emit_task_group_started {
     ($name:expr, $sequential:expr, $task_count:expr) => {
@@ -158,9 +325,25 @@ macro_rules! emit_task_group_started {
             task_count = $task_count,
         )
     };
+    ($name:expr, $sequential:expr, $task_count:expr, $parent_group:expr, $max_concurrency:expr) => {
+        ::tracing::info!(
+            target: "cuenv::task",
+            event_type = "task.group_started",
+            task_name = %$name,
+            sequential = $sequential,
+            task_count = $task_count,
+            parent_group = ?$parent_group,
+            max_concurrency = ?$max_concurrency,
+        )
+    };
 }
 
 /// Emit a task group completed event.
+///
+/// Forms:
+/// - `emit_task_group_completed!(name, success, duration_ms)`
+/// - `emit_task_group_completed!(name, success, duration_ms, succeeded, failed, skipped)`
+/// - `emit_task_group_completed!(name, success, duration_ms, succeeded, failed, skipped, parent_group)`
 #[macro_export]
 macro_rules! emit_task_group_completed {
     ($name:expr, $success:expr, $duration_ms:expr) => {
@@ -170,6 +353,31 @@ macro_rules! emit_task_group_completed {
             task_name = %$name,
             success = $success,
             duration_ms = $duration_ms,
+        )
+    };
+    ($name:expr, $success:expr, $duration_ms:expr, $succeeded:expr, $failed:expr, $skipped:expr) => {
+        ::tracing::info!(
+            target: "cuenv::task",
+            event_type = "task.group_completed",
+            task_name = %$name,
+            success = $success,
+            duration_ms = $duration_ms,
+            succeeded = $succeeded,
+            failed_count = $failed,
+            skipped_count = $skipped,
+        )
+    };
+    ($name:expr, $success:expr, $duration_ms:expr, $succeeded:expr, $failed:expr, $skipped:expr, $parent_group:expr) => {
+        ::tracing::info!(
+            target: "cuenv::task",
+            event_type = "task.group_completed",
+            task_name = %$name,
+            success = $success,
+            duration_ms = $duration_ms,
+            succeeded = $succeeded,
+            failed_count = $failed,
+            skipped_count = $skipped,
+            parent_group = ?$parent_group,
         )
     };
 }
@@ -602,6 +810,27 @@ macro_rules! emit_stderr {
     };
 }
 
+/// Internal helpers used by the `emit_*!` macros.
+///
+/// Not part of the stable public API — exposed only because exported macros
+/// must reference it via `$crate`.
+#[doc(hidden)]
+pub mod __macro_helpers {
+    use crate::event::{CacheSkipReason, SkipReason};
+
+    /// Serialize a [`CacheSkipReason`] to JSON for tracing field transport.
+    #[must_use]
+    pub fn encode_cache_skip_reason(reason: &CacheSkipReason) -> String {
+        serde_json::to_string(reason).unwrap_or_default()
+    }
+
+    /// Serialize a [`SkipReason`] to JSON for tracing field transport.
+    #[must_use]
+    pub fn encode_skip_reason(reason: &SkipReason) -> String {
+        serde_json::to_string(reason).unwrap_or_default()
+    }
+}
+
 /// Print to stdout with automatic secret redaction (with newline).
 ///
 /// Use this instead of `println!` when output might contain secrets.
@@ -644,6 +873,40 @@ mod tests {
             emit_task_completed!("build", true, Some(0), 1000_u64);
             emit_task_group_started!("all", false, 3_usize);
             emit_task_group_completed!("all", true, 5000_u64);
+        });
+    }
+
+    #[tokio::test]
+    async fn test_task_macros_extended_forms_compile() {
+        use crate::event::{CacheSkipReason, SkipReason, TaskKind};
+        with_test_subscriber(|| {
+            let parent: Option<&str> = Some("ci");
+            emit_task_started!("ci.build", "cargo build", true, parent, "task");
+            let _ = TaskKind::Task;
+            emit_task_cache_hit!("ci.build", "abc123", parent);
+            emit_task_cache_miss!("ci.test", parent);
+            emit_task_cache_skipped!("ci.fmt", CacheSkipReason::EmptyInputs, parent);
+            emit_task_queued!("ci.lint", 2_usize, parent);
+            emit_task_skipped!(
+                "ci.deploy",
+                SkipReason::DependencyFailed {
+                    dep: "ci.build".to_string()
+                },
+                parent
+            );
+            emit_task_retrying!("ci.flaky", 2_u32, 3_u32, parent);
+            emit_task_output!("ci.build", "stdout", "out", parent);
+            emit_task_completed!("ci.build", true, Some(0), 1000_u64, parent);
+            emit_task_group_started!("ci", false, 3_usize, None::<&str>, Some(4_u32));
+            emit_task_group_completed!(
+                "ci",
+                true,
+                5000_u64,
+                3_usize,
+                0_usize,
+                0_usize,
+                None::<&str>
+            );
         });
     }
 

--- a/crates/events/src/renderers/cli.rs
+++ b/crates/events/src/renderers/cli.rs
@@ -86,6 +86,7 @@ impl CliRenderer {
                 name,
                 command,
                 hermetic,
+                ..
             } => {
                 let hermetic_indicator = if *hermetic { " (hermetic)" } else { "" };
                 eprintln!("> [{name}] {command}{hermetic_indicator}");
@@ -93,10 +94,35 @@ impl CliRenderer {
             TaskEvent::CacheHit { name, .. } => {
                 eprintln!("> [{name}] (cached)");
             }
-            TaskEvent::CacheMiss { name } => {
+            TaskEvent::CacheMiss { name, .. } => {
                 if self.config.verbose {
                     eprintln!("> [{name}] cache miss, executing...");
                 }
+            }
+            TaskEvent::CacheSkipped { name, reason, .. } => {
+                if self.config.verbose {
+                    eprintln!("> [{name}] cache skipped: {reason}");
+                }
+            }
+            TaskEvent::Queued {
+                name,
+                queue_position,
+                ..
+            } => {
+                if self.config.verbose {
+                    eprintln!("> [{name}] queued (position {queue_position})");
+                }
+            }
+            TaskEvent::Skipped { name, reason, .. } => {
+                eprintln!("> [{name}] skipped ({reason})");
+            }
+            TaskEvent::Retrying {
+                name,
+                attempt,
+                max_attempts,
+                ..
+            } => {
+                eprintln!("> [{name}] retrying (attempt {attempt}/{max_attempts})");
             }
             TaskEvent::Output {
                 stream, content, ..
@@ -123,6 +149,7 @@ impl CliRenderer {
                 name,
                 sequential,
                 task_count,
+                ..
             } => {
                 let mode = if *sequential {
                     "sequential"
@@ -135,10 +162,16 @@ impl CliRenderer {
                 name,
                 success,
                 duration_ms,
+                succeeded,
+                failed,
+                skipped,
+                ..
             } => {
                 if self.config.verbose {
                     let status = if *success { "completed" } else { "failed" };
-                    eprintln!("> Group {name} {status} in {duration_ms}ms");
+                    eprintln!(
+                        "> Group {name} {status} in {duration_ms}ms ({succeeded} ok, {failed} failed, {skipped} skipped)"
+                    );
                 }
             }
         }
@@ -398,6 +431,8 @@ mod tests {
             name: "test-task".to_string(),
             command: "echo hello".to_string(),
             hermetic: false,
+            parent_group: None,
+            task_kind: crate::event::TaskKind::Task,
         }));
         renderer.render(&event);
     }
@@ -409,6 +444,8 @@ mod tests {
             name: "test-task".to_string(),
             command: "echo hello".to_string(),
             hermetic: true,
+            parent_group: None,
+            task_kind: crate::event::TaskKind::Task,
         }));
         renderer.render(&event);
     }
@@ -419,6 +456,7 @@ mod tests {
         let event = make_event(EventCategory::Task(TaskEvent::CacheHit {
             name: "cached-task".to_string(),
             cache_key: "abc123".to_string(),
+            parent_group: None,
         }));
         renderer.render(&event);
     }
@@ -432,6 +470,62 @@ mod tests {
         let renderer = CliRenderer::with_config(config);
         let event = make_event(EventCategory::Task(TaskEvent::CacheMiss {
             name: "uncached-task".to_string(),
+            parent_group: None,
+        }));
+        renderer.render(&event);
+    }
+
+    #[test]
+    fn test_render_task_cache_skipped_verbose() {
+        let config = CliRendererConfig {
+            colors: false,
+            verbose: true,
+        };
+        let renderer = CliRenderer::with_config(config);
+        let event = make_event(EventCategory::Task(TaskEvent::CacheSkipped {
+            name: "fmt".to_string(),
+            parent_group: None,
+            reason: crate::event::CacheSkipReason::EmptyInputs,
+        }));
+        renderer.render(&event);
+    }
+
+    #[test]
+    fn test_render_task_skipped() {
+        let renderer = CliRenderer::new();
+        let event = make_event(EventCategory::Task(TaskEvent::Skipped {
+            name: "deploy".to_string(),
+            parent_group: None,
+            reason: crate::event::SkipReason::DependencyFailed {
+                dep: "build".to_string(),
+            },
+        }));
+        renderer.render(&event);
+    }
+
+    #[test]
+    fn test_render_task_queued_verbose() {
+        let config = CliRendererConfig {
+            colors: false,
+            verbose: true,
+        };
+        let renderer = CliRenderer::with_config(config);
+        let event = make_event(EventCategory::Task(TaskEvent::Queued {
+            name: "build".to_string(),
+            parent_group: None,
+            queue_position: 1,
+        }));
+        renderer.render(&event);
+    }
+
+    #[test]
+    fn test_render_task_retrying() {
+        let renderer = CliRenderer::new();
+        let event = make_event(EventCategory::Task(TaskEvent::Retrying {
+            name: "flaky".to_string(),
+            parent_group: None,
+            attempt: 2,
+            max_attempts: 3,
         }));
         renderer.render(&event);
     }
@@ -443,6 +537,7 @@ mod tests {
             name: "task".to_string(),
             stream: Stream::Stdout,
             content: "stdout content".to_string(),
+            parent_group: None,
         }));
         renderer.render(&event);
     }
@@ -454,6 +549,7 @@ mod tests {
             name: "task".to_string(),
             stream: Stream::Stderr,
             content: "stderr content".to_string(),
+            parent_group: None,
         }));
         renderer.render(&event);
     }
@@ -470,6 +566,7 @@ mod tests {
             success: true,
             exit_code: Some(0),
             duration_ms: 1000,
+            parent_group: None,
         }));
         renderer.render(&event);
     }
@@ -486,6 +583,7 @@ mod tests {
             success: false,
             exit_code: Some(1),
             duration_ms: 500,
+            parent_group: None,
         }));
         renderer.render(&event);
     }
@@ -497,6 +595,8 @@ mod tests {
             name: "group".to_string(),
             sequential: true,
             task_count: 5,
+            parent_group: None,
+            max_concurrency: None,
         }));
         renderer.render(&event);
     }
@@ -508,6 +608,8 @@ mod tests {
             name: "group".to_string(),
             sequential: false,
             task_count: 3,
+            parent_group: None,
+            max_concurrency: Some(4),
         }));
         renderer.render(&event);
     }
@@ -523,6 +625,10 @@ mod tests {
             name: "group".to_string(),
             success: true,
             duration_ms: 2000,
+            parent_group: None,
+            succeeded: 3,
+            failed: 0,
+            skipped: 0,
         }));
         renderer.render(&event);
     }


### PR DESCRIPTION
## Summary

Foundation phase (Phase 0 of an 8-phase plan) that makes `CuenvEvent` rich enough that any renderer — plain CLI spinner, ratatui TUI, JSON, future iocraft port — can show task hierarchy, cache decisions, and structured lifecycle without having to infer anything from task names.

- **New TaskEvent fields**: `parent_group: Option<String>` on every variant; `task_kind` on `Started`; `max_concurrency` on `GroupStarted`; `succeeded`/`failed`/`skipped` counts on `GroupCompleted`. All additive with serde defaults — wire format stays backward compatible.
- **New TaskEvent variants**: `CacheSkipped` (with structured `CacheSkipReason`: empty_inputs, non_path_ref, runtime_env, hasher_root_mismatch, hash_failed, disabled, never_mode, no_resolved_inputs), `Queued`, `Skipped` (with `SkipReason::DependencyFailed { dep }` / `ManuallyDisabled`), `Retrying`.
- **Macros**: every `emit_task_*!` macro gets an extended arm taking `parent_group`; new macros `emit_task_cache_skipped!`, `emit_task_queued!`, `emit_task_skipped!`, `emit_task_retrying!`. Existing 3-arg call sites continue to compile.
- **Layer visitor** extracts new fields via `record_str`/`i64`/`u64`/`debug`, including JSON-encoded enums for structured reasons.
- **CliRenderer** handles every new variant (verbose mode for now — the real group-aware spinner lands in Phase 4).
- **Executor wiring**: `crates/core/src/tasks/cache.rs` — `build_action` now returns `CacheOutcome::{Eligible, Skipped(reason)}` instead of `Option<…>`, so the executor can surface `cache_hit`/`cache_miss`/`cache_skipped` events at the call site. Group emission paired with `group_started` at all three sites (sequential, parallel default-task short-circuit, parallel children). Existing cache tests adjusted at the helper boundary; behavior unchanged.

## Test plan

- [x] `cargo test -p cuenv-events` (147 unit tests + 3 doctests pass)
- [x] `cargo test -p cuenv-core` (642 unit tests pass — every `build_action_*` test plus full suite)
- [x] `cargo check --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cuenv fmt --fix`
- [x] `cuenv sync ci --check`
- [x] `cuenv task ci.schema-docs-check`
- [x] `nix flake check -L --accept-flake-config`

## Out of scope

Group-aware spinner CLI rendering (Phase 4), TUI replay tooling (Phase 1), scrollback / 30 FPS / expanded log view (Phase 2), `ActivityModel`/`UiState` split (Phase 3), parallel CI orchestrator (Phase 5), `continueOnError` (Phase 6), bounded output ring buffer (Phase 7).