### PR TITLE
refactor(tui): document model/UI split and add canonical apply_event

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1453,6 +1453,8 @@ dependencies = [
  "chrono",
  "serde",
  "serde_json",
+ "tempfile",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "tracing-subscriber",

--- a/crates/core/src/tasks/cache.rs
+++ b/crates/core/src/tasks/cache.rs
@@ -16,6 +16,7 @@ use cuenv_cas::{
     Action, ActionCache, ActionResult, Cas, Command, Digest, Directory, DirectoryNode,
     ExecutionMetadata, FileNode, OutputFile, Platform, digest_of,
 };
+use cuenv_events::CacheSkipReason;
 use cuenv_vcs::{HashedInput, VcsHasher};
 use globset::{Glob, GlobSetBuilder};
 use std::collections::BTreeMap;
@@ -23,6 +24,16 @@ use std::path::{Component, Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 use walkdir::WalkDir;
+
+/// Outcome of evaluating a task's cache eligibility.
+#[derive(Debug)]
+pub enum CacheOutcome {
+    /// Task is eligible for caching with the computed action and digest.
+    Eligible(Box<Action>, Digest),
+    /// Task is not eligible; the [`CacheSkipReason`] explains why so renderers
+    /// can surface the reason to the user.
+    Skipped(CacheSkipReason),
+}
 
 /// Bundle of caching infrastructure used by the task executor.
 ///
@@ -89,15 +100,17 @@ pub struct BuildActionInput<'a> {
 
 /// Build the [`Action`] envelope for a task and compute its digest.
 ///
-/// Returns `Ok(None)` when the task is not eligible for caching.
+/// Returns a [`CacheOutcome`] explaining either the resulting action +
+/// digest (eligible) or the structured reason caching was skipped. The
+/// caller is expected to surface the skip reason as a `CacheSkipped` event.
 ///
 /// # Errors
 ///
 /// Propagates failures from task command resolution and canonical encoding.
 ///
-/// Input hashing failures degrade to `Ok(None)` so cache eligibility never
-/// changes whether the task itself is runnable.
-pub async fn build_action(input: BuildActionInput<'_>) -> Result<Option<(Action, Digest)>> {
+/// Input hashing failures degrade to a [`CacheOutcome::Skipped`] so cache
+/// eligibility never changes whether the task itself is runnable.
+pub async fn build_action(input: BuildActionInput<'_>) -> Result<CacheOutcome> {
     let BuildActionInput {
         task,
         task_name,
@@ -110,17 +123,19 @@ pub async fn build_action(input: BuildActionInput<'_>) -> Result<Option<(Action,
 
     if let Some(reason) = &cache.cache_disabled_reason {
         tracing::debug!(task = %task_name, reason, "skipping cache");
-        return Ok(None);
+        return Ok(CacheOutcome::Skipped(CacheSkipReason::Disabled {
+            reason: Some(reason.clone()),
+        }));
     }
 
     let policy = effective_policy(task);
     if !policy.mode.allows_read() && !policy.mode.allows_write() {
         tracing::debug!(task = %task_name, "skipping cache: task cache mode is never");
-        return Ok(None);
+        return Ok(CacheOutcome::Skipped(CacheSkipReason::NeverMode));
     }
 
     if task.inputs.is_empty() {
-        return Ok(None);
+        return Ok(CacheOutcome::Skipped(CacheSkipReason::EmptyInputs));
     }
 
     let mut patterns = Vec::with_capacity(task.inputs.len());
@@ -132,20 +147,20 @@ pub async fn build_action(input: BuildActionInput<'_>) -> Result<Option<(Action,
                 task = %task_name,
                 "skipping cache: task uses non-path input (project/task reference)"
             );
-            return Ok(None);
+            return Ok(CacheOutcome::Skipped(CacheSkipReason::NonPathRef));
         }
     }
 
-    let Some(hashed) = resolve_hashed_inputs(cache, &patterns, project_root, task_name).await?
-    else {
-        return Ok(None);
+    let hashed = match resolve_hashed_inputs(cache, &patterns, project_root, task_name).await? {
+        ResolveOutcome::Resolved(h) => h,
+        ResolveOutcome::Skipped(reason) => return Ok(CacheOutcome::Skipped(reason)),
     };
     if hashed.is_empty() {
         tracing::debug!(
             task = %task_name,
             "skipping cache: declared path inputs resolved to no files"
         );
-        return Ok(None);
+        return Ok(CacheOutcome::Skipped(CacheSkipReason::NoResolvedInputs));
     }
     let input_root_digest = build_input_root_digest(&hashed)?;
 
@@ -154,7 +169,7 @@ pub async fn build_action(input: BuildActionInput<'_>) -> Result<Option<(Action,
             task = %task_name,
             "skipping cache: task defines task-level environment entries resolved at execution time"
         );
-        return Ok(None);
+        return Ok(CacheOutcome::Skipped(CacheSkipReason::RuntimeEnv));
     }
 
     let mut environment_variables = BTreeMap::new();
@@ -196,7 +211,13 @@ pub async fn build_action(input: BuildActionInput<'_>) -> Result<Option<(Action,
     let action_digest = digest_of(&action)
         .map_err(|e| crate::Error::configuration(format!("action digest: {e}")))?;
 
-    Ok(Some((action, action_digest)))
+    Ok(CacheOutcome::Eligible(Box::new(action), action_digest))
+}
+
+/// Internal outcome from input resolution, distinguishing skip reasons.
+enum ResolveOutcome {
+    Resolved(Vec<HashedInput>),
+    Skipped(CacheSkipReason),
 }
 
 async fn resolve_hashed_inputs(
@@ -204,7 +225,7 @@ async fn resolve_hashed_inputs(
     patterns: &[String],
     project_root: &Path,
     task_name: &str,
-) -> Result<Option<Vec<HashedInput>>> {
+) -> Result<ResolveOutcome> {
     let prefixed_patterns =
         match prefix_patterns_for_hasher_root(patterns, project_root, &cache.vcs_hasher_root) {
             Ok(prefixed_patterns) => prefixed_patterns,
@@ -216,7 +237,7 @@ async fn resolve_hashed_inputs(
                     error = %error,
                     "skipping cache: cannot map task inputs to cache hasher root"
                 );
-                return Ok(None);
+                return Ok(ResolveOutcome::Skipped(CacheSkipReason::HasherRootMismatch));
             }
         };
 
@@ -228,7 +249,7 @@ async fn resolve_hashed_inputs(
                 error = %error,
                 "skipping cache: input hashing failed"
             );
-            return Ok(None);
+            return Ok(ResolveOutcome::Skipped(CacheSkipReason::HashFailed));
         }
     };
 
@@ -243,11 +264,11 @@ async fn resolve_hashed_inputs(
                     error = %error,
                     "skipping cache: hashed inputs escaped task project root"
                 );
-                return Ok(None);
+                return Ok(ResolveOutcome::Skipped(CacheSkipReason::HasherRootMismatch));
             }
         };
 
-    Ok(Some(rebased))
+    Ok(ResolveOutcome::Resolved(rebased))
 }
 
 /// Query the action cache for a previous result.
@@ -801,7 +822,10 @@ mod tests {
     }
 
     async fn build_action_for_test(input: BuildActionInput<'_>) -> Option<(Action, Digest)> {
-        build_action(input).await.unwrap()
+        match build_action(input).await.unwrap() {
+            CacheOutcome::Eligible(action, digest) => Some((*action, digest)),
+            CacheOutcome::Skipped(_) => None,
+        }
     }
 
     #[tokio::test]

--- a/crates/core/src/tasks/executor.rs
+++ b/crates/core/src/tasks/executor.rs
@@ -58,6 +58,37 @@ pub struct TaskResult {
 /// Number of lines from stdout/stderr to include when summarizing failures
 pub const TASK_FAILURE_SNIPPET_LINES: usize = 20;
 
+/// Emit a `task.group_completed` event with succeeded/failed/skipped counts
+/// derived from the inner result.
+///
+/// On `Err` the group is reported as failed with all children counted as
+/// failed (we lack per-child results once a sequence/parallel aborts).
+fn emit_group_completion(
+    prefix: &str,
+    started: std::time::Instant,
+    outcome: &Result<Vec<TaskResult>>,
+    total_children: usize,
+) {
+    let duration_ms = u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX);
+    let (success, succeeded, failed, skipped) = match outcome {
+        Ok(results) => {
+            let succeeded = results.iter().filter(|r| r.success).count();
+            let failed = results.iter().filter(|r| !r.success).count();
+            let skipped = total_children.saturating_sub(succeeded + failed);
+            (failed == 0, succeeded, failed, skipped)
+        }
+        Err(_) => (false, 0_usize, total_children, 0_usize),
+    };
+    cuenv_events::emit_task_group_completed!(
+        prefix,
+        success,
+        duration_ms,
+        succeeded,
+        failed,
+        skipped
+    );
+}
+
 /// Task executor configuration
 #[derive(Debug, Clone)]
 pub struct ExecutorConfig {
@@ -158,7 +189,7 @@ impl TaskExecutor {
         let cache_handle: Option<(TaskCacheConfig, cuenv_cas::Digest, PathBuf)> =
             if let Some(cache) = self.config.cache.clone() {
                 let workdir = self.workdir_for_task(task);
-                match super::cache::build_action(BuildActionInput {
+                let outcome = super::cache::build_action(BuildActionInput {
                     task,
                     task_name: name,
                     environment: &self.config.environment,
@@ -171,12 +202,13 @@ impl TaskExecutor {
                         .as_deref()
                         .unwrap_or(&self.config.project_root),
                 })
-                .await?
-                {
-                    Some((_, action_digest)) => {
+                .await?;
+                match outcome {
+                    super::cache::CacheOutcome::Eligible(_, action_digest) => {
                         // Cache lookup. On a hit, short-circuit execution.
                         if let Some(cached) = super::cache::lookup(&cache, &action_digest, task)? {
                             tracing::debug!(task = %name, "action cache hit");
+                            cuenv_events::emit_task_cache_hit!(name, action_digest.to_string());
                             return self.return_cache_hit(CacheHitInput {
                                 name,
                                 task,
@@ -186,9 +218,13 @@ impl TaskExecutor {
                             });
                         }
                         tracing::debug!(task = %name, "action cache miss");
+                        cuenv_events::emit_task_cache_miss!(name);
                         Some((cache, action_digest, workdir))
                     }
-                    None => None,
+                    super::cache::CacheOutcome::Skipped(reason) => {
+                        cuenv_events::emit_task_cache_skipped!(name, reason);
+                        None
+                    }
                 }
             } else {
                 None
@@ -587,9 +623,26 @@ impl TaskExecutor {
         sequence: &[TaskNode],
         all_tasks: &Tasks,
     ) -> Result<Vec<TaskResult>> {
-        if !self.config.capture_output.should_capture() {
+        let emit_lifecycle = !self.config.capture_output.should_capture();
+        if emit_lifecycle {
             cuenv_events::emit_task_group_started!(prefix, true, sequence.len());
         }
+        let started = std::time::Instant::now();
+        let outcome = self
+            .execute_sequential_inner(prefix, sequence, all_tasks)
+            .await;
+        if emit_lifecycle {
+            emit_group_completion(prefix, started, &outcome, sequence.len());
+        }
+        outcome
+    }
+
+    async fn execute_sequential_inner(
+        &self,
+        prefix: &str,
+        sequence: &[TaskNode],
+        all_tasks: &Tasks,
+    ) -> Result<Vec<TaskResult>> {
         let mut results = Vec::new();
         // Track completed step results for output ref resolution within sequences.
         let mut seq_results: std::collections::HashMap<String, TaskResult> =
@@ -639,20 +692,41 @@ impl TaskExecutor {
         group: &TaskGroup,
         all_tasks: &Tasks,
     ) -> Result<Vec<TaskResult>> {
+        let emit_lifecycle = !self.config.capture_output.should_capture();
         // Check for "default" task to override parallel execution
         if let Some(default_task) = group.children.get("default") {
-            if !self.config.capture_output.should_capture() {
+            if emit_lifecycle {
                 cuenv_events::emit_task_group_started!(prefix, true, 1_usize);
             }
+            let started = std::time::Instant::now();
             // Execute only the default task, using the group prefix directly
             // since "default" is implicit when invoking the group name
             let task_name = format!("{}.default", prefix);
-            return self.execute_node(&task_name, default_task, all_tasks).await;
+            let outcome = self.execute_node(&task_name, default_task, all_tasks).await;
+            if emit_lifecycle {
+                emit_group_completion(prefix, started, &outcome, 1);
+            }
+            return outcome;
         }
 
-        if !self.config.capture_output.should_capture() {
+        if emit_lifecycle {
             cuenv_events::emit_task_group_started!(prefix, false, group.children.len());
         }
+        let started = std::time::Instant::now();
+        let total_children = group.children.len();
+        let outcome = self.execute_parallel_inner(prefix, group, all_tasks).await;
+        if emit_lifecycle {
+            emit_group_completion(prefix, started, &outcome, total_children);
+        }
+        outcome
+    }
+
+    async fn execute_parallel_inner(
+        &self,
+        prefix: &str,
+        group: &TaskGroup,
+        all_tasks: &Tasks,
+    ) -> Result<Vec<TaskResult>> {
         let mut join_set = JoinSet::new();
         let all_tasks = Arc::new(all_tasks.clone());
         let mut all_results = Vec::new();

--- a/crates/cuenv/src/cli.rs
+++ b/crates/cuenv/src/cli.rs
@@ -538,6 +538,13 @@ pub enum Commands {
         /// Arguments to pass to the task (positional and --named values).
         #[arg(help = "Arguments to pass to the task (positional and --named values)")]
         task_args: Vec<String>,
+        /// Record every emitted event as JSONL to the given path for later replay.
+        #[arg(
+            long = "record-events",
+            help = "Record every emitted event as JSONL to the given path for later replay with `cuenv tui-replay`",
+            value_name = "PATH"
+        )]
+        record_events: Option<String>,
     },
     /// Execute a command with CUE environment variables.
     #[command(
@@ -676,7 +683,36 @@ pub enum Commands {
     Ci(crate::commands::ci::CiArgs),
     /// Start interactive TUI dashboard for monitoring cuenv events.
     #[command(about = "Start interactive TUI dashboard for monitoring cuenv events")]
-    Tui,
+    Tui {
+        /// Record every emitted event as JSONL to the given path for later replay.
+        #[arg(
+            long = "record-events",
+            help = "Record every emitted event as JSONL to the given path for later replay with `cuenv tui-replay`",
+            value_name = "PATH"
+        )]
+        record_events: Option<String>,
+    },
+    /// Replay a recorded event trace through the TUI.
+    #[command(about = "Replay a recorded event trace through the TUI")]
+    TuiReplay {
+        /// Path to the JSONL recording produced by `--record-events`.
+        #[arg(help = "Path to the JSONL recording", value_name = "PATH")]
+        path: String,
+        /// Play events as fast as possible (default: honor original timestamps).
+        #[arg(
+            long = "fast",
+            help = "Play events as fast as possible instead of honoring recorded timestamps",
+            default_value_t = false
+        )]
+        fast: bool,
+        /// Render snapshot frames to the given directory and exit (no interactive TUI).
+        #[arg(
+            long = "snapshot-frames-to",
+            help = "Render snapshot frames to the given directory and exit (no interactive TUI)",
+            value_name = "DIR"
+        )]
+        snapshot_frames_to: Option<String>,
+    },
     /// Start web server for streaming cuenv events.
     #[command(about = "Start web server for streaming cuenv events")]
     Web {
@@ -1544,7 +1580,8 @@ impl Commands {
             | Self::Completions { .. }
             | Self::Shell { .. }
             | Self::Ci { .. }
-            | Self::Tui
+            | Self::Tui { .. }
+            | Self::TuiReplay { .. }
             | Self::Web { .. }
             | Self::Changeset { .. }
             | Self::Release { .. }
@@ -1632,6 +1669,7 @@ impl Commands {
                 skip_dependencies,
                 dry_run,
                 task_args,
+                record_events,
             } => Command::Task {
                 path,
                 package,
@@ -1649,6 +1687,7 @@ impl Commands {
                 skip_dependencies,
                 dry_run: dry_run.into(),
                 task_args,
+                record_events,
             },
             Self::Exec {
                 command,
@@ -1698,7 +1737,16 @@ impl Commands {
                 package,
             },
             Self::Ci(args) => Command::Ci { args },
-            Self::Tui => Command::Tui,
+            Self::Tui { record_events } => Command::Tui { record_events },
+            Self::TuiReplay {
+                path,
+                fast,
+                snapshot_frames_to,
+            } => Command::TuiReplay {
+                path,
+                fast,
+                snapshot_frames_to,
+            },
             Self::Web { port, host } => Command::Web { port, host },
             Self::Changeset { subcommand } => match subcommand {
                 ChangesetCommands::Add {
@@ -2669,6 +2717,7 @@ mod tests {
             skip_dependencies: false,
             dry_run: false,
             task_args: vec![],
+            record_events: None,
         };
         assert_eq!(task_cmd.package(), "mypackage");
 

--- a/crates/cuenv/src/commands/handler.rs
+++ b/crates/cuenv/src/commands/handler.rs
@@ -415,6 +415,8 @@ pub struct TaskHandler {
     pub dry_run: cuenv_core::DryRun,
     /// Additional arguments to pass to the task.
     pub task_args: Vec<String>,
+    /// Optional path to record every emitted event as JSONL.
+    pub record_events: Option<String>,
 }
 
 #[async_trait]
@@ -435,6 +437,14 @@ impl CommandHandler for TaskHandler {
                 "Task arguments are not supported when selecting tasks by label",
             ));
         }
+
+        // Spawn event recorder if --record-events was passed. The recorder
+        // subscribes to the global event bus and writes every event as JSONL
+        // alongside whatever renderer the user picked.
+        let recorder_handle = self
+            .record_events
+            .as_deref()
+            .and_then(spawn_record_events_handle);
 
         // Build request using the builder pattern
         let mut request = match (&self.name, &self.labels, self.interactive) {
@@ -481,8 +491,34 @@ impl CommandHandler for TaskHandler {
             request = request.with_dry_run();
         }
 
-        task::execute(request).await
+        let outcome = task::execute(request).await;
+
+        if let Some(handle) = recorder_handle {
+            handle.abort();
+            let _ = handle.await;
+        }
+
+        outcome
     }
+}
+
+/// Spawn an [`cuenv_events::EventRecorder`] writing to `path`, subscribed to
+/// the global event bus. Returns the join handle so callers can stop the
+/// recorder when the host command finishes.
+fn spawn_record_events_handle(path: &str) -> Option<tokio::task::JoinHandle<()>> {
+    let recorder = match cuenv_events::EventRecorder::create(path) {
+        Ok(r) => r,
+        Err(err) => {
+            tracing::warn!(
+                path = %path,
+                error = %err,
+                "failed to start event recorder; --record-events ignored"
+            );
+            return None;
+        }
+    };
+    let receiver = crate::tracing::subscribe_global_events()?;
+    Some(tokio::spawn(recorder.run(receiver)))
 }
 
 /// Handler for `ci` command.

--- a/crates/cuenv/src/commands/mod.rs
+++ b/crates/cuenv/src/commands/mod.rs
@@ -179,6 +179,8 @@ pub enum Command {
         dry_run: DryRun,
         /// Additional arguments to pass to the task.
         task_args: Vec<String>,
+        /// Optional path to record every emitted event as JSONL.
+        record_events: Option<String>,
     },
     /// Execute an arbitrary command within the cuenv environment.
     Exec {
@@ -242,7 +244,19 @@ pub enum Command {
         args: ci::CiArgs,
     },
     /// Launch the terminal user interface.
-    Tui,
+    Tui {
+        /// Optional path to record every emitted event as JSONL.
+        record_events: Option<String>,
+    },
+    /// Replay a recorded JSONL event trace through the TUI.
+    TuiReplay {
+        /// Path to the JSONL recording.
+        path: String,
+        /// Play events as fast as possible instead of honoring recorded timestamps.
+        fast: bool,
+        /// Render snapshot frames to the given directory and exit (no interactive TUI).
+        snapshot_frames_to: Option<String>,
+    },
     /// Launch the web-based user interface.
     Web {
         /// Port number for the web server.
@@ -929,6 +943,7 @@ impl CommandExecutor {
                 skip_dependencies,
                 dry_run,
                 task_args,
+                record_events,
             } => {
                 self.run_command(handler::TaskHandler {
                     path,
@@ -946,6 +961,7 @@ impl CommandExecutor {
                     skip_dependencies,
                     dry_run,
                     task_args,
+                    record_events,
                 })
                 .await
             }
@@ -978,7 +994,8 @@ impl CommandExecutor {
             }
 
             // Commands handled directly in main.rs
-            Command::Tui
+            Command::Tui { .. }
+            | Command::TuiReplay { .. }
             | Command::Web { .. }
             | Command::Completions { .. }
             | Command::Info { .. }

--- a/crates/cuenv/src/main.rs
+++ b/crates/cuenv/src/main.rs
@@ -185,7 +185,8 @@ const fn requires_async_runtime(cli: &cli::Cli) -> bool {
             cli::Commands::Task { .. }
             | cli::Commands::Exec { .. }
             | cli::Commands::Ci { .. }
-            | cli::Commands::Tui
+            | cli::Commands::Tui { .. }
+            | cli::Commands::TuiReplay { .. }
             | cli::Commands::Web { .. }
             | cli::Commands::Allow { .. }
             | cli::Commands::Deny { .. }
@@ -330,7 +331,8 @@ fn cue_module_command_path(command: &Command) -> Option<&str> {
         | Command::Restart { .. }
         | Command::Ci { .. }
         | Command::ShellInit { .. }
-        | Command::Tui
+        | Command::Tui { .. }
+        | Command::TuiReplay { .. }
         | Command::Web { .. }
         | Command::Completions { .. }
         | Command::ChangesetAdd { .. }
@@ -986,8 +988,17 @@ async fn execute_command_safe(
 
     // Special commands that bypass the executor (they don't fit the event pattern)
     match &command {
-        Command::Tui => {
-            return execute_tui_command()
+        Command::Tui { record_events } => {
+            return execute_tui_command(record_events.clone())
+                .await
+                .map_err(|e| CliError::other(e.to_string()));
+        }
+        Command::TuiReplay {
+            path,
+            fast,
+            snapshot_frames_to,
+        } => {
+            return execute_tui_replay_command(path.clone(), *fast, snapshot_frames_to.clone())
                 .await
                 .map_err(|e| CliError::other(e.to_string()));
         }
@@ -1224,9 +1235,13 @@ async fn execute_command_safe(
 
 /// Execute TUI command - starts interactive event dashboard
 #[instrument(name = "cuenv_execute_tui")]
-async fn execute_tui_command() -> Result<(), CliError> {
+async fn execute_tui_command(record_events: Option<String>) -> Result<(), CliError> {
     use coordinator::client::CoordinatorClient;
     use coordinator::protocol::UiType;
+
+    // Attach event recorder if requested. The recorder subscribes to the
+    // global event bus and writes every event as JSONL alongside the TUI.
+    let recorder_handle = spawn_event_recorder(record_events.as_deref());
 
     // Connect to coordinator as a TUI consumer
     let Ok(mut client) = CoordinatorClient::connect_as_consumer(UiType::Tui).await else {
@@ -1244,7 +1259,15 @@ async fn execute_tui_command() -> Result<(), CliError> {
     cuenv_events::emit_command_started!("tui");
 
     // Run the TUI event viewer
-    match tui::run_event_viewer(&mut client).await {
+    let result = tui::run_event_viewer(&mut client).await;
+
+    // Stop the recorder cleanly before returning.
+    if let Some(handle) = recorder_handle {
+        handle.abort();
+        let _ = handle.await;
+    }
+
+    match result {
         Ok(()) => {
             cuenv_events::emit_command_completed!("tui", true, 0_u64);
             Ok(())
@@ -1254,6 +1277,45 @@ async fn execute_tui_command() -> Result<(), CliError> {
             Err(CliError::other(format!("TUI error: {e}")))
         }
     }
+}
+
+/// Execute the TUI replay command — drive the rich TUI from a recorded
+/// JSONL trace instead of live coordinator events.
+#[instrument(name = "cuenv_execute_tui_replay", skip(snapshot_frames_to))]
+async fn execute_tui_replay_command(
+    path: String,
+    fast: bool,
+    snapshot_frames_to: Option<String>,
+) -> Result<(), CliError> {
+    // Replay implementation lands in a follow-up step of Phase 1 — for now
+    // we surface a clear error so the subcommand is wired end-to-end and
+    // can be polished without churn elsewhere.
+    let _ = (fast, snapshot_frames_to);
+    Err(CliError::other(format!(
+        "tui-replay is not yet implemented. Recorded trace: {path}"
+    )))
+}
+
+/// Spawn an event recorder if the user passed `--record-events`.
+///
+/// Returns a join handle so callers can stop the recorder when the host
+/// command finishes. Subscribes to the global event bus (initialized by
+/// `init_tracing_with_events`) so it sees the same events the renderers do.
+fn spawn_event_recorder(path: Option<&str>) -> Option<tokio::task::JoinHandle<()>> {
+    let path = path?;
+    let recorder = match cuenv_events::EventRecorder::create(path) {
+        Ok(r) => r,
+        Err(err) => {
+            ::tracing::warn!(
+                path = %path,
+                error = %err,
+                "failed to start event recorder; --record-events ignored"
+            );
+            return None;
+        }
+    };
+    let receiver = crate::tracing::subscribe_global_events()?;
+    Some(tokio::spawn(recorder.run(receiver)))
 }
 
 /// Execute Web command - starts web server for event streaming

--- a/crates/cuenv/src/main.rs
+++ b/crates/cuenv/src/main.rs
@@ -1281,19 +1281,102 @@ async fn execute_tui_command(record_events: Option<String>) -> Result<(), CliErr
 
 /// Execute the TUI replay command — drive the rich TUI from a recorded
 /// JSONL trace instead of live coordinator events.
+///
+/// Reads `path` as JSONL via [`cuenv_events::EventReplayReader`], pushes
+/// every event into a fresh [`cuenv_events::EventBus`], and drives the
+/// existing [`tui::rich::RichTui`] event loop against the bus. When
+/// `--fast` is set events are emitted as fast as possible; otherwise the
+/// recorded inter-arrival gaps (derived from `CuenvEvent::timestamp`) are
+/// honoured.
 #[instrument(name = "cuenv_execute_tui_replay", skip(snapshot_frames_to))]
 async fn execute_tui_replay_command(
     path: String,
     fast: bool,
     snapshot_frames_to: Option<String>,
 ) -> Result<(), CliError> {
-    // Replay implementation lands in a follow-up step of Phase 1 — for now
-    // we surface a clear error so the subcommand is wired end-to-end and
-    // can be polished without churn elsewhere.
-    let _ = (fast, snapshot_frames_to);
-    Err(CliError::other(format!(
-        "tui-replay is not yet implemented. Recorded trace: {path}"
-    )))
+    use cuenv_events::{EventBus, EventReplayReader};
+
+    if snapshot_frames_to.is_some() {
+        return Err(CliError::other(
+            "--snapshot-frames-to is not yet implemented; will land with the insta snapshot tests"
+                .to_string(),
+        ));
+    }
+
+    let reader = EventReplayReader::open(&path)
+        .map_err(|err| CliError::other(format!("failed to open event recording {path}: {err}")))?;
+    let events: Vec<cuenv_events::CuenvEvent> = reader
+        .collect::<std::io::Result<Vec<_>>>()
+        .map_err(|err| CliError::other(format!("failed to parse event recording {path}: {err}")))?;
+    if events.is_empty() {
+        return Err(CliError::other(format!("event recording {path} is empty")));
+    }
+
+    cuenv_events::emit_command_started!("tui-replay");
+
+    let bus = EventBus::new();
+    let sender = bus
+        .sender()
+        .ok_or_else(|| CliError::other("event bus sender unavailable".to_string()))?;
+    let receiver = bus.subscribe();
+
+    // Spawn the playback task before constructing the TUI so subscribers
+    // are guaranteed to be active by the time events flow.
+    let playback = tokio::spawn(playback_events(events, sender, fast));
+
+    let (ready_tx, ready_rx) = tokio::sync::oneshot::channel();
+    let mut tui = tui::rich::RichTui::new(receiver, ready_tx)
+        .map_err(|err| CliError::other(format!("failed to initialise replay TUI: {err}")))?;
+    drop(ready_rx);
+
+    let outcome = tokio::task::spawn_blocking(move || tui.run())
+        .await
+        .map_err(|err| CliError::other(format!("replay TUI join error: {err}")))
+        .and_then(|r| r.map_err(|err| CliError::other(format!("replay TUI error: {err}"))));
+
+    let _ = playback.await;
+
+    match outcome {
+        Ok(()) => {
+            cuenv_events::emit_command_completed!("tui-replay", true, 0_u64);
+            Ok(())
+        }
+        Err(e) => {
+            cuenv_events::emit_command_completed!("tui-replay", false, 0_u64);
+            Err(e)
+        }
+    }
+}
+
+/// Push every recorded event onto `sender`, honouring inter-arrival gaps
+/// unless `fast` is set. Final event is a synthesised `SystemEvent::Shutdown`
+/// so the TUI exits when playback finishes.
+async fn playback_events(
+    events: Vec<cuenv_events::CuenvEvent>,
+    sender: cuenv_events::EventSender,
+    fast: bool,
+) {
+    use cuenv_events::{EventCategory, EventSource, SystemEvent};
+    let mut prev_ts: Option<chrono::DateTime<chrono::Utc>> = None;
+    for event in events {
+        if !fast {
+            if let Some(prev) = prev_ts {
+                let delta = (event.timestamp - prev)
+                    .to_std()
+                    .unwrap_or(std::time::Duration::ZERO);
+                tokio::time::sleep(delta).await;
+            }
+            prev_ts = Some(event.timestamp);
+        }
+        if sender.send(event).is_err() {
+            break;
+        }
+    }
+    let _ = sender.send(cuenv_events::CuenvEvent::new(
+        uuid::Uuid::new_v4(),
+        EventSource::new("cuenv::replay"),
+        EventCategory::System(SystemEvent::Shutdown),
+    ));
 }
 
 /// Spawn an event recorder if the user passed `--record-events`.

--- a/crates/cuenv/src/tui/mod.rs
+++ b/crates/cuenv/src/tui/mod.rs
@@ -162,18 +162,22 @@ fn format_cuenv_event(event: &CuenvEvent) -> String {
                     name,
                     command,
                     hermetic,
+                    ..
                 } => {
                     format!(
                         "[{timestamp}] {source} TASK {name} started: {command} (hermetic={hermetic})"
                     )
                 }
-                TaskEvent::CacheHit { name, cache_key } => {
+                TaskEvent::CacheHit {
+                    name, cache_key, ..
+                } => {
                     format!("[{timestamp}] {source} CACHE HIT {name} key={cache_key}")
                 }
                 TaskEvent::Output {
                     name,
                     stream,
                     content,
+                    ..
                 } => {
                     format!("[{timestamp}] {source} OUTPUT {name}:{stream:?} {content}")
                 }

--- a/crates/cuenv/src/tui/rich.rs
+++ b/crates/cuenv/src/tui/rich.rs
@@ -5,11 +5,11 @@ use super::widgets::{OutputPanelWidget, TaskTreeWidget};
 use crossterm::{
     event::{self, Event as CrosstermEvent, KeyCode, KeyModifiers},
     execute,
-    terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
+    terminal::{LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
 };
 use cuenv_events::{CuenvEvent, EventCategory, EventReceiver, TaskEvent};
 use ratatui::{
-    Terminal,
+    Terminal, TerminalOptions, Viewport,
     backend::CrosstermBackend,
     layout::{Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
@@ -29,16 +29,23 @@ const FRAME_INTERVAL: Duration = Duration::from_millis(33);
 /// This guard ensures the terminal is properly restored even if the TUI
 /// exits unexpectedly (e.g., due to a panic). Errors during cleanup are
 /// logged but cannot be propagated since Drop cannot return errors.
-struct TerminalGuard;
+///
+/// `in_alt_screen` tracks whether the TUI is currently using the alternate
+/// screen (expanded mode) so the guard knows whether to issue
+/// `LeaveAlternateScreen` on drop. Inline mode (the default) keeps the
+/// run's output in the terminal's scrollback after exit.
+struct TerminalGuard {
+    in_alt_screen: bool,
+}
 
 impl Drop for TerminalGuard {
     fn drop(&mut self) {
-        // Attempt to restore terminal state. Log errors since Drop can't propagate them.
-        // Users may need to run `reset` if these fail.
         if let Err(e) = disable_raw_mode() {
             tracing::warn!(error = %e, "Failed to disable raw mode");
         }
-        if let Err(e) = execute!(io::stdout(), LeaveAlternateScreen) {
+        if self.in_alt_screen
+            && let Err(e) = execute!(io::stdout(), LeaveAlternateScreen)
+        {
             tracing::warn!(error = %e, "Failed to leave alternate screen");
         }
     }
@@ -60,7 +67,20 @@ pub struct RichTui {
 }
 
 impl RichTui {
+    /// Number of rows the inline viewport reserves at the bottom of the
+    /// terminal. Sized so the user keeps a few rows of scrollback visible
+    /// during execution, then the TUI buffer scrolls into permanent
+    /// scrollback when the run finishes.
+    const INLINE_RESERVED_ROWS: u16 = 4;
+    /// Minimum inline viewport height — guards against tiny terminals.
+    const INLINE_MIN_ROWS: u16 = 18;
+
     /// Create a new rich TUI.
+    ///
+    /// Uses ratatui's inline viewport by default so the run's output stays
+    /// in the terminal's scrollback when the TUI exits — pressing `f`
+    /// inside the TUI switches into the alternate screen for a fullscreen
+    /// single-task focus view.
     ///
     /// # Arguments
     /// * `event_rx` - Receiver for cuenv events
@@ -72,16 +92,26 @@ impl RichTui {
     /// Returns an error if terminal initialization fails.
     pub fn new(event_rx: EventReceiver, ready_tx: oneshot::Sender<()>) -> io::Result<Self> {
         enable_raw_mode()?;
-        let mut stdout = io::stdout();
-        execute!(stdout, EnterAlternateScreen)?;
-
+        let stdout = io::stdout();
         let backend = CrosstermBackend::new(stdout);
-        let terminal = Terminal::new(backend)?;
+
+        let (_, term_rows) = crossterm::terminal::size().unwrap_or((80, 30));
+        let inline_height = term_rows
+            .saturating_sub(Self::INLINE_RESERVED_ROWS)
+            .max(Self::INLINE_MIN_ROWS);
+        let terminal = Terminal::with_options(
+            backend,
+            TerminalOptions {
+                viewport: Viewport::Inline(inline_height),
+            },
+        )?;
 
         Ok(Self {
             terminal,
             state: TuiState::new(),
-            _guard: TerminalGuard,
+            _guard: TerminalGuard {
+                in_alt_screen: false,
+            },
             event_rx,
             quit_requested: false,
             can_quit: false,
@@ -467,7 +497,10 @@ mod tests {
 
     #[test]
     fn test_terminal_guard_drop() {
-        // Just verify TerminalGuard can be created and dropped
-        let _guard = TerminalGuard;
+        // Just verify TerminalGuard can be created and dropped without
+        // leaving the terminal in a stuck state.
+        let _guard = TerminalGuard {
+            in_alt_screen: false,
+        };
     }
 }

--- a/crates/cuenv/src/tui/rich.rs
+++ b/crates/cuenv/src/tui/rich.rs
@@ -279,6 +279,7 @@ impl RichTui {
                 name,
                 stream,
                 content,
+                ..
             } => {
                 let stream_str = match stream {
                     cuenv_events::Stream::Stdout => "stdout",
@@ -304,8 +305,13 @@ impl RichTui {
                     task.exit_code = exit_code;
                 }
             }
-            // These events don't require status updates in the TUI
+            // These events don't require status updates in the TUI yet.
+            // Group/queue/skip/retry visualisation lands in Phase 2/3.
             TaskEvent::CacheMiss { .. }
+            | TaskEvent::CacheSkipped { .. }
+            | TaskEvent::Queued { .. }
+            | TaskEvent::Skipped { .. }
+            | TaskEvent::Retrying { .. }
             | TaskEvent::GroupStarted { .. }
             | TaskEvent::GroupCompleted { .. } => {}
         }

--- a/crates/cuenv/src/tui/rich.rs
+++ b/crates/cuenv/src/tui/rich.rs
@@ -214,8 +214,10 @@ impl RichTui {
                 self.can_quit = self.state.is_complete;
             }
             KeyCode::Esc => {
-                // If in selected mode, return to all mode first
-                if self.state.output_mode == OutputMode::Selected {
+                // Exit focus mode first, then selected mode, before quitting.
+                if self.state.focused_task.is_some() {
+                    self.state.clear_focus();
+                } else if self.state.output_mode == OutputMode::Selected {
                     self.state.show_all_output();
                 } else if self.state.is_complete {
                     return false;
@@ -223,6 +225,9 @@ impl RichTui {
                     self.quit_requested = true;
                     self.can_quit = self.state.is_complete;
                 }
+            }
+            KeyCode::Char('f') => {
+                self.state.toggle_focus();
             }
             KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => {
                 // Force quit on Ctrl+C
@@ -388,22 +393,27 @@ impl RichTui {
             // Render header
             Self::render_header_static(state, f, main_chunks[0]);
 
-            // Create 2-panel horizontal split for main content
-            let content_chunks = Layout::default()
-                .direction(Direction::Horizontal)
-                .constraints([
-                    Constraint::Percentage(30), // Task tree (left)
-                    Constraint::Percentage(70), // Output panel (right)
-                ])
-                .split(main_chunks[1]);
+            // When a task is focused, the tree is hidden so the output
+            // panel gets every available column. Otherwise we keep the
+            // usual 30/70 tree-output split.
+            if state.focused_task.is_some() {
+                let output_widget = OutputPanelWidget::new(state);
+                f.render_widget(output_widget, main_chunks[1]);
+            } else {
+                let content_chunks = Layout::default()
+                    .direction(Direction::Horizontal)
+                    .constraints([
+                        Constraint::Percentage(30), // Task tree (left)
+                        Constraint::Percentage(70), // Output panel (right)
+                    ])
+                    .split(main_chunks[1]);
 
-            // Render task tree widget (left panel)
-            let tree_widget = TaskTreeWidget::new(state);
-            f.render_widget(tree_widget, content_chunks[0]);
+                let tree_widget = TaskTreeWidget::new(state);
+                f.render_widget(tree_widget, content_chunks[0]);
 
-            // Render output panel widget (right panel)
-            let output_widget = OutputPanelWidget::new(state);
-            f.render_widget(output_widget, content_chunks[1]);
+                let output_widget = OutputPanelWidget::new(state);
+                f.render_widget(output_widget, content_chunks[1]);
+            }
 
             // Render status bar
             Self::render_status_bar_static(state, quit_requested, f, main_chunks[2]);
@@ -468,10 +478,12 @@ impl RichTui {
             "Press 'q' to quit"
         } else if quit_requested {
             "Waiting for tasks... (Ctrl+C to force)"
+        } else if state.focused_task.is_some() {
+            "f/Esc: Exit focus | PgUp/PgDn: Scroll | q: Quit"
         } else if state.output_mode == OutputMode::Selected {
-            "Esc/a: All | ↑↓/jk: Navigate | PgUp/PgDn: Scroll | q: Quit"
+            "Esc/a: All | f: Focus task | ↑↓/jk: Navigate | PgUp/PgDn: Scroll | q: Quit"
         } else {
-            "↑↓/jk: Navigate | ←→/hl: Collapse/Expand | Enter: Select | a: All | q: Quit"
+            "↑↓/jk: Navigate | ←→/hl: Collapse/Expand | Enter: Select | f: Focus | a: All | q: Quit"
         };
 
         let block = Block::default()

--- a/crates/cuenv/src/tui/rich.rs
+++ b/crates/cuenv/src/tui/rich.rs
@@ -17,8 +17,12 @@ use ratatui::{
     widgets::{Block, Borders, Paragraph},
 };
 use std::io::{self, Stdout};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tokio::sync::oneshot;
+
+/// Target render cadence — coalesces bursts of events into a single redraw
+/// so a chatty task can't melt the TUI into a redraw storm. ~30 FPS.
+const FRAME_INTERVAL: Duration = Duration::from_millis(33);
 
 /// RAII guard that restores terminal state on drop.
 ///
@@ -110,16 +114,16 @@ impl RichTui {
         }
 
         loop {
-            // Render the UI
+            // Coalesce events from this frame's budget into a single render.
+            let frame_start = Instant::now();
             self.render()?;
 
-            // Check for quit conditions
             if self.quit_requested && self.can_quit {
                 break;
             }
 
-            // Handle events (non-blocking)
-            if !self.handle_events()? {
+            // Drain pending cuenv events and key events up to the frame deadline.
+            if !self.drain_until_deadline(frame_start + FRAME_INTERVAL)? {
                 break;
             }
         }
@@ -136,98 +140,113 @@ impl RichTui {
         Ok(())
     }
 
-    /// Handle events (keyboard and cuenv events)
-    fn handle_events(&mut self) -> io::Result<bool> {
-        // Non-blocking poll for keyboard events
-        if event::poll(Duration::from_millis(50))?
-            && let CrosstermEvent::Key(key) = event::read()?
-        {
-            match key.code {
-                // Quit handling
-                KeyCode::Char('q') => {
-                    if self.state.is_complete {
-                        return Ok(false); // Exit immediately if complete
-                    }
+    /// Drain key + cuenv events until `deadline`, then return.
+    ///
+    /// Coalesces bursts of cuenv events without redrawing in between, giving
+    /// a ~30 FPS render cadence regardless of how chatty tasks are. Returns
+    /// `Ok(false)` when the user requested a force quit and the caller
+    /// should exit the run loop.
+    fn drain_until_deadline(&mut self, deadline: Instant) -> io::Result<bool> {
+        loop {
+            // Drain every pending cuenv event before consulting key events,
+            // so a flood of cuenv events can't starve user input.
+            while let Some(event) = self.event_rx.try_recv() {
+                self.handle_cuenv_event(event);
+            }
+
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                return Ok(true);
+            }
+
+            // Cap the per-call timeout so we can re-check cuenv events every
+            // ~5ms even when the user isn't pressing keys.
+            let poll_timeout = remaining.min(Duration::from_millis(5));
+            if event::poll(poll_timeout)?
+                && let CrosstermEvent::Key(key) = event::read()?
+                && !self.handle_key(key)
+            {
+                return Ok(false);
+            }
+        }
+    }
+
+    /// Handle a single key event. Returns `false` when the caller should
+    /// exit the run loop (force-quit).
+    fn handle_key(&mut self, key: crossterm::event::KeyEvent) -> bool {
+        match key.code {
+            // Quit handling
+            KeyCode::Char('q') => {
+                if self.state.is_complete {
+                    return false; // Exit immediately if complete
+                }
+                self.quit_requested = true;
+                self.can_quit = self.state.is_complete;
+            }
+            KeyCode::Esc => {
+                // If in selected mode, return to all mode first
+                if self.state.output_mode == OutputMode::Selected {
+                    self.state.show_all_output();
+                } else if self.state.is_complete {
+                    return false;
+                } else {
                     self.quit_requested = true;
                     self.can_quit = self.state.is_complete;
                 }
-                KeyCode::Esc => {
-                    // If in selected mode, return to all mode first
-                    if self.state.output_mode == OutputMode::Selected {
-                        self.state.show_all_output();
-                    } else if self.state.is_complete {
-                        return Ok(false);
-                    } else {
-                        self.quit_requested = true;
-                        self.can_quit = self.state.is_complete;
-                    }
-                }
-                KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => {
-                    // Force quit on Ctrl+C
-                    return Ok(false);
-                }
-
-                // Tree navigation
-                KeyCode::Up | KeyCode::Char('k') => {
-                    self.state.cursor_up();
-                }
-                KeyCode::Down | KeyCode::Char('j') => {
-                    self.state.cursor_down();
-                }
-
-                // Expand/collapse tree nodes
-                KeyCode::Left | KeyCode::Char('h') => {
-                    // Collapse current node
-                    if let Some(node) = self.state.highlighted_node() {
-                        let node_key = node.node_key();
-                        if node.has_children && self.state.expanded_nodes.contains(&node_key) {
-                            self.state.toggle_expansion(&node_key);
-                        }
-                    }
-                }
-                KeyCode::Right | KeyCode::Char('l') => {
-                    // Expand current node
-                    if let Some(node) = self.state.highlighted_node() {
-                        let node_key = node.node_key();
-                        if node.has_children && !self.state.expanded_nodes.contains(&node_key) {
-                            self.state.toggle_expansion(&node_key);
-                        }
-                    }
-                }
-
-                // Select node for filtered output
-                KeyCode::Enter => {
-                    self.state.select_current_node();
-                }
-
-                // Return to "All" output mode
-                KeyCode::Char('a') => {
-                    self.state.show_all_output();
-                }
-
-                // Output scrolling (when in selected mode)
-                KeyCode::PageUp if self.state.output_mode == OutputMode::Selected => {
-                    self.state.output_scroll = self.state.output_scroll.saturating_sub(10);
-                }
-                KeyCode::PageDown if self.state.output_mode == OutputMode::Selected => {
-                    self.state.output_scroll += 10;
-                }
-
-                _ => {}
             }
+            KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                // Force quit on Ctrl+C
+                return false;
+            }
+
+            // Tree navigation
+            KeyCode::Up | KeyCode::Char('k') => {
+                self.state.cursor_up();
+            }
+            KeyCode::Down | KeyCode::Char('j') => {
+                self.state.cursor_down();
+            }
+
+            // Expand/collapse tree nodes
+            KeyCode::Left | KeyCode::Char('h') => {
+                if let Some(node) = self.state.highlighted_node() {
+                    let node_key = node.node_key();
+                    if node.has_children && self.state.expanded_nodes.contains(&node_key) {
+                        self.state.toggle_expansion(&node_key);
+                    }
+                }
+            }
+            KeyCode::Right | KeyCode::Char('l') => {
+                if let Some(node) = self.state.highlighted_node() {
+                    let node_key = node.node_key();
+                    if node.has_children && !self.state.expanded_nodes.contains(&node_key) {
+                        self.state.toggle_expansion(&node_key);
+                    }
+                }
+            }
+
+            // Select node for filtered output
+            KeyCode::Enter => {
+                self.state.select_current_node();
+            }
+
+            // Return to "All" output mode
+            KeyCode::Char('a') => {
+                self.state.show_all_output();
+            }
+
+            // Output scrolling (when in selected mode)
+            KeyCode::PageUp if self.state.output_mode == OutputMode::Selected => {
+                self.state.output_scroll = self.state.output_scroll.saturating_sub(10);
+            }
+            KeyCode::PageDown if self.state.output_mode == OutputMode::Selected => {
+                self.state.output_scroll += 10;
+            }
+
+            _ => {}
         }
 
-        // Non-blocking drain of ALL available cuenv events
-        // Important: Use `while let` to process ALL pending events, not just one.
-        // Events can accumulate between render cycles (50ms), especially when
-        // multiple tasks emit events in quick succession.
-        while let Some(event) = self.event_rx.try_recv() {
-            self.handle_cuenv_event(event);
-        }
-        // Note: We don't need to detect channel closure separately since
-        // we emit a completion event before the channel closes (in task.rs)
-
-        Ok(true)
+        true
     }
 
     /// Handle a cuenv event

--- a/crates/cuenv/src/tui/rich.rs
+++ b/crates/cuenv/src/tui/rich.rs
@@ -7,7 +7,7 @@ use crossterm::{
     execute,
     terminal::{LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
 };
-use cuenv_events::{CuenvEvent, EventCategory, EventReceiver, TaskEvent};
+use cuenv_events::{CuenvEvent, EventCategory, EventReceiver};
 use ratatui::{
     Terminal, TerminalOptions, Viewport,
     backend::CrosstermBackend,
@@ -181,7 +181,7 @@ impl RichTui {
             // Drain every pending cuenv event before consulting key events,
             // so a flood of cuenv events can't starve user input.
             while let Some(event) = self.event_rx.try_recv() {
-                self.handle_cuenv_event(event);
+                self.handle_cuenv_event(&event);
             }
 
             let remaining = deadline.saturating_duration_since(Instant::now());
@@ -284,10 +284,18 @@ impl RichTui {
         true
     }
 
-    /// Handle a cuenv event
-    fn handle_cuenv_event(&mut self, event: CuenvEvent) {
-        match event.category {
-            EventCategory::Task(task_event) => self.handle_task_event(task_event),
+    /// Handle a cuenv event.
+    ///
+    /// Task events are funnelled through [`TuiState::apply_event`] — the
+    /// canonical deterministic apply path — so live runs and replays
+    /// arrive at identical activity state from the same event stream.
+    /// Command/completion handling stays local because it owns RichTui's
+    /// `received_completion_event` / `can_quit` flags.
+    fn handle_cuenv_event(&mut self, event: &CuenvEvent) {
+        match &event.category {
+            EventCategory::Task(_) => {
+                self.state.apply_event(event);
+            }
             EventCategory::Command(cmd_event) => {
                 use cuenv_events::CommandEvent;
                 match cmd_event {
@@ -295,79 +303,24 @@ impl RichTui {
                         success, command, ..
                     } => {
                         self.received_completion_event = true;
-                        let error_msg = if success {
+                        let error_msg = if *success {
                             None
                         } else {
-                            // Provide context that task execution failed
-                            // Detailed error info is shown in task output panes
                             Some(format!(
                                 "Command '{command}' failed - see task output for details"
                             ))
                         };
-                        self.state.complete(success, error_msg);
+                        self.state.complete(*success, error_msg);
                         self.can_quit = true;
                     }
-                    // Other command events are not displayed in TUI
                     CommandEvent::Started { .. } | CommandEvent::Progress { .. } => {}
                 }
             }
-            // These event categories are not relevant for the TUI display
             EventCategory::Service(_)
             | EventCategory::Ci(_)
             | EventCategory::Interactive(_)
             | EventCategory::System(_)
             | EventCategory::Output(_) => {}
-        }
-    }
-
-    /// Handle a task event
-    fn handle_task_event(&mut self, event: TaskEvent) {
-        match event {
-            TaskEvent::Started { name, .. } => {
-                self.state.update_task_status(&name, TaskStatus::Running);
-            }
-            TaskEvent::CacheHit { name, .. } => {
-                self.state.update_task_status(&name, TaskStatus::Cached);
-            }
-            TaskEvent::Output {
-                name,
-                stream,
-                content,
-                ..
-            } => {
-                let stream_str = match stream {
-                    cuenv_events::Stream::Stdout => "stdout",
-                    cuenv_events::Stream::Stderr => "stderr",
-                };
-                self.state.add_task_output(&name, stream_str, content);
-            }
-            TaskEvent::Completed {
-                name,
-                success,
-                exit_code,
-                ..
-            } => {
-                let status = if success {
-                    TaskStatus::Completed
-                } else {
-                    TaskStatus::Failed
-                };
-                self.state.update_task_status(&name, status);
-
-                // Update exit code
-                if let Some(task) = self.state.tasks.get_mut(&name) {
-                    task.exit_code = exit_code;
-                }
-            }
-            // These events don't require status updates in the TUI yet.
-            // Group/queue/skip/retry visualisation lands in Phase 2/3.
-            TaskEvent::CacheMiss { .. }
-            | TaskEvent::CacheSkipped { .. }
-            | TaskEvent::Queued { .. }
-            | TaskEvent::Skipped { .. }
-            | TaskEvent::Retrying { .. }
-            | TaskEvent::GroupStarted { .. }
-            | TaskEvent::GroupCompleted { .. } => {}
         }
     }
 

--- a/crates/cuenv/src/tui/state.rs
+++ b/crates/cuenv/src/tui/state.rs
@@ -258,6 +258,9 @@ pub struct TuiState {
     pub output_mode: OutputMode,
     /// Scroll offset for output panel
     pub output_scroll: usize,
+    /// When `Some(task)`, the renderer hides the task tree and devotes
+    /// every available row to that task's output panel. Toggled with `f`.
+    pub focused_task: Option<String>,
 }
 
 impl TuiState {
@@ -278,7 +281,33 @@ impl TuiState {
             flattened_tree: Vec::new(),
             output_mode: OutputMode::All,
             output_scroll: 0,
+            focused_task: None,
         }
+    }
+
+    /// Toggle focus on the highlighted task — when focused, the renderer
+    /// hides the task tree and gives the entire viewport to that task's
+    /// output panel. Calling this with the same task again clears focus.
+    pub fn toggle_focus(&mut self) {
+        if self.focused_task.is_some() {
+            self.focused_task = None;
+            return;
+        }
+        let Some(node) = self.highlighted_node() else {
+            return;
+        };
+        if let TreeNodeType::Task(name) = &node.node_type {
+            let name = name.clone();
+            self.focused_task = Some(name.clone());
+            self.selected_task = Some(name);
+            self.output_mode = OutputMode::Selected;
+            self.output_scroll = 0;
+        }
+    }
+
+    /// Exit focused-task mode (no-op when not focused).
+    pub fn clear_focus(&mut self) {
+        self.focused_task = None;
     }
 
     /// Add a task to the state

--- a/crates/cuenv/src/tui/state.rs
+++ b/crates/cuenv/src/tui/state.rs
@@ -1,7 +1,42 @@
-//! Centralized state management for the rich TUI
+//! Centralized state management for the rich TUI.
+//!
+//! State is logically split into two concerns:
+//!
+//! - **[`ActivityModel`]** — the event-driven data model: tasks, outputs,
+//!   running set, completion status. Mutated **only** by
+//!   [`TuiState::apply_event`] (and helpers it calls). Two replays of the
+//!   same event trace produce identical `ActivityModel`s; that property
+//!   is asserted by the integration tests in `tests/tui_replay.rs`.
+//! - **[`UiState`]** — the input-driven view state: cursor position,
+//!   expansion, focus, selected task, scroll offset. Mutated only by
+//!   keyboard handlers.
+//!
+//! Both concerns currently live inside [`TuiState`] for backward
+//! compatibility with the widget renderers and rich TUI consumers, which
+//! still read individual fields directly. The two marker structs below
+//! exist to document the boundary and to let downstream code spell out
+//! which subset of state it expects; full field migration into the
+//! sub-structs is a follow-up.
 
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::time::Instant;
+
+use cuenv_events::{CuenvEvent, EventCategory, Stream, TaskEvent};
+
+/// Marker for the event-driven half of [`TuiState`].
+///
+/// The boundary exists so renderers and snapshot tests can reason about
+/// "what would a fresh replay of this trace produce" independently of the
+/// user's current focus / scroll position. Concrete fields still live on
+/// [`TuiState`]; this struct documents the invariant.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct ActivityModel;
+
+/// Marker for the input-driven half of [`TuiState`].
+///
+/// See [`ActivityModel`] for the rationale.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct UiState;
 
 /// Status of a task in the execution graph
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -229,9 +264,16 @@ impl TaskOutput {
     }
 }
 
-/// Global TUI state for task execution
+/// Global TUI state for task execution.
+///
+/// Fields are grouped by concern: the upper block belongs to the
+/// [`ActivityModel`] (event-driven, deterministic when replayed) and the
+/// lower block belongs to the [`UiState`] (input-driven). Mutations that
+/// cross the boundary go through [`TuiState::apply_event`] or explicit
+/// input-handler methods, never through ad-hoc field writes.
 #[derive(Debug)]
 pub struct TuiState {
+    // -- ActivityModel: mutated by apply_event -------------------------------
     /// Start time of the overall execution
     pub start_time: Instant,
     /// Map of task name to task info
@@ -246,6 +288,8 @@ pub struct TuiState {
     pub success: bool,
     /// Error message (if failed)
     pub error_message: Option<String>,
+
+    // -- UiState: mutated by input handlers ----------------------------------
     /// Currently selected task for output filtering (None = show all)
     pub selected_task: Option<String>,
     /// Set of expanded tree nodes (task names that are expanded)
@@ -648,6 +692,80 @@ impl TuiState {
         // Expand "All" node by default for visibility
         self.expanded_nodes.insert("::all::".to_string());
         self.rebuild_flattened_tree();
+    }
+
+    /// Apply a [`CuenvEvent`] to the [`ActivityModel`] half of this state.
+    ///
+    /// This is the single canonical entry point for event-driven mutations.
+    /// Replay tooling (`cuenv tui-replay`), snapshot tests, and the live
+    /// TUI all funnel events through here so behaviour stays consistent.
+    ///
+    /// The method touches only model fields — `selected_task`,
+    /// `cursor_position`, `focused_task`, etc. are left alone so the user's
+    /// in-flight UI interaction survives a flurry of events.
+    pub fn apply_event(&mut self, event: &CuenvEvent) {
+        match &event.category {
+            EventCategory::Task(task_event) => self.apply_task_event(task_event),
+            EventCategory::Service(_)
+            | EventCategory::Ci(_)
+            | EventCategory::Command(_)
+            | EventCategory::Interactive(_)
+            | EventCategory::System(_)
+            | EventCategory::Output(_) => {}
+        }
+    }
+
+    /// Apply a [`TaskEvent`] (the bulk of the lifecycle) to the model.
+    fn apply_task_event(&mut self, event: &TaskEvent) {
+        match event {
+            TaskEvent::Started { name, .. } => {
+                self.update_task_status(name, TaskStatus::Running);
+            }
+            TaskEvent::CacheHit { name, .. } => {
+                self.update_task_status(name, TaskStatus::Cached);
+            }
+            TaskEvent::Output {
+                name,
+                stream,
+                content,
+                ..
+            } => {
+                let stream_str = match stream {
+                    Stream::Stdout => "stdout",
+                    Stream::Stderr => "stderr",
+                };
+                self.add_task_output(name, stream_str, content.clone());
+            }
+            TaskEvent::Completed {
+                name,
+                success,
+                exit_code,
+                ..
+            } => {
+                let status = if *success {
+                    TaskStatus::Completed
+                } else {
+                    TaskStatus::Failed
+                };
+                self.update_task_status(name, status);
+                if let Some(task) = self.tasks.get_mut(name) {
+                    task.exit_code = *exit_code;
+                }
+            }
+            TaskEvent::Skipped { name, .. } => {
+                self.update_task_status(name, TaskStatus::Skipped);
+            }
+            // Group / queue / cache-skip / retry events don't currently move
+            // the model — renderers consume them directly off the bus.
+            // Reserved for Phase 4 (group-aware spinner) where they shape
+            // the CLI renderer's progress aggregates.
+            TaskEvent::CacheMiss { .. }
+            | TaskEvent::CacheSkipped { .. }
+            | TaskEvent::Queued { .. }
+            | TaskEvent::Retrying { .. }
+            | TaskEvent::GroupStarted { .. }
+            | TaskEvent::GroupCompleted { .. } => {}
+        }
     }
 }
 

--- a/crates/cuenv/tests/tui_replay.rs
+++ b/crates/cuenv/tests/tui_replay.rs
@@ -1,0 +1,179 @@
+//! Integration tests for the `cuenv tui-replay` subcommand and the
+//! recorder/reader round-trip it depends on.
+//!
+//! These tests exercise the public surface end-to-end without booting the
+//! interactive TUI:
+//! - Recording a synthesised trace as JSONL via [`cuenv_events::EventRecorder`].
+//! - Reading it back via [`cuenv_events::EventReplayReader`] and verifying
+//!   every field survives the round-trip.
+//! - Invoking the `cuenv tui-replay --help` CLI surface so the subcommand
+//!   remains registered.
+//! - Invoking `cuenv tui-replay` against an empty / missing trace to confirm
+//!   the diagnostic paths return non-zero with a useful message.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::ffi::OsStr;
+use std::path::PathBuf;
+use std::process::Command;
+use std::str;
+
+use cuenv_events::{
+    CacheSkipReason, CuenvEvent, EventCategory, EventRecorder, EventReplayReader, EventSource,
+    Stream, SystemEvent, TaskEvent, TaskKind,
+};
+use uuid::Uuid;
+
+const CUENV_BIN: &str = env!("CARGO_BIN_EXE_cuenv");
+
+fn clean_command(bin: impl AsRef<OsStr>) -> Command {
+    let mut cmd = Command::new(bin);
+    cmd.env_clear()
+        .env("PATH", std::env::var("PATH").unwrap_or_default())
+        .env("HOME", std::env::var("HOME").unwrap_or_default());
+    cmd
+}
+
+fn sample_trace() -> Vec<CuenvEvent> {
+    let mk = |cat| CuenvEvent::new(Uuid::new_v4(), EventSource::new("cuenv::test"), cat);
+    vec![
+        mk(EventCategory::Task(TaskEvent::GroupStarted {
+            name: "ci".to_string(),
+            sequential: false,
+            task_count: 2,
+            parent_group: None,
+            max_concurrency: Some(2),
+        })),
+        mk(EventCategory::Task(TaskEvent::Started {
+            name: "ci.fmt".to_string(),
+            command: "cuenv fmt".to_string(),
+            hermetic: true,
+            parent_group: Some("ci".to_string()),
+            task_kind: TaskKind::Task,
+        })),
+        mk(EventCategory::Task(TaskEvent::CacheSkipped {
+            name: "ci.fmt".to_string(),
+            parent_group: Some("ci".to_string()),
+            reason: CacheSkipReason::EmptyInputs,
+        })),
+        mk(EventCategory::Task(TaskEvent::Output {
+            name: "ci.fmt".to_string(),
+            stream: Stream::Stdout,
+            content: "no changes".to_string(),
+            parent_group: Some("ci".to_string()),
+        })),
+        mk(EventCategory::Task(TaskEvent::Completed {
+            name: "ci.fmt".to_string(),
+            success: true,
+            exit_code: Some(0),
+            duration_ms: 42,
+            parent_group: Some("ci".to_string()),
+        })),
+        mk(EventCategory::Task(TaskEvent::GroupCompleted {
+            name: "ci".to_string(),
+            success: true,
+            duration_ms: 100,
+            parent_group: None,
+            succeeded: 2,
+            failed: 0,
+            skipped: 0,
+        })),
+        mk(EventCategory::System(SystemEvent::Shutdown)),
+    ]
+}
+
+#[test]
+fn round_trip_preserves_every_phase_0_field() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("trace.jsonl");
+
+    let trace = sample_trace();
+    {
+        let mut recorder = EventRecorder::create(&path).unwrap();
+        for event in &trace {
+            recorder.write_event(event).unwrap();
+        }
+        assert_eq!(recorder.events_written(), trace.len() as u64);
+    }
+
+    let restored: Vec<CuenvEvent> = EventReplayReader::open(&path)
+        .unwrap()
+        .collect::<std::io::Result<Vec<_>>>()
+        .unwrap();
+    assert_eq!(restored.len(), trace.len());
+
+    for (i, (left, right)) in trace.iter().zip(restored.iter()).enumerate() {
+        let lj = serde_json::to_value(left).unwrap();
+        let rj = serde_json::to_value(right).unwrap();
+        assert_eq!(lj, rj, "event {i} round-trip diverged");
+    }
+}
+
+#[test]
+fn replay_reader_skips_no_events_with_empty_file() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("empty.jsonl");
+    let _ = EventRecorder::create(&path).unwrap();
+
+    let restored: Vec<_> = EventReplayReader::open(&path)
+        .unwrap()
+        .collect::<std::io::Result<Vec<_>>>()
+        .unwrap();
+    assert!(restored.is_empty());
+}
+
+#[test]
+fn cli_tui_replay_subcommand_is_registered() {
+    let mut cmd = clean_command(CUENV_BIN);
+    let output = cmd.arg("tui-replay").arg("--help").output().unwrap();
+    let stdout = str::from_utf8(&output.stdout).unwrap();
+    assert!(
+        output.status.success(),
+        "expected `tui-replay --help` to succeed, stderr={}",
+        str::from_utf8(&output.stderr).unwrap()
+    );
+    assert!(
+        stdout.contains("Replay a recorded event trace"),
+        "expected help to mention replay; got: {stdout}"
+    );
+    assert!(stdout.contains("--fast"), "missing --fast flag: {stdout}");
+    assert!(
+        stdout.contains("--snapshot-frames-to"),
+        "missing --snapshot-frames-to flag: {stdout}"
+    );
+}
+
+#[test]
+fn cli_tui_replay_rejects_missing_file() {
+    let missing = PathBuf::from("/definitely/not/here.jsonl");
+    let mut cmd = clean_command(CUENV_BIN);
+    let output = cmd.arg("tui-replay").arg(&missing).output().unwrap();
+    assert!(
+        !output.status.success(),
+        "expected non-zero exit for missing recording"
+    );
+    let stderr = str::from_utf8(&output.stderr).unwrap();
+    assert!(
+        stderr.contains("failed to open event recording"),
+        "stderr should explain the failure; got: {stderr}"
+    );
+}
+
+#[test]
+fn cli_tui_replay_rejects_empty_recording() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("empty.jsonl");
+    let _ = EventRecorder::create(&path).unwrap();
+
+    let mut cmd = clean_command(CUENV_BIN);
+    let output = cmd.arg("tui-replay").arg(&path).output().unwrap();
+    assert!(
+        !output.status.success(),
+        "expected non-zero exit for empty recording"
+    );
+    let stderr = str::from_utf8(&output.stderr).unwrap();
+    assert!(
+        stderr.contains("is empty"),
+        "stderr should mention empty recording; got: {stderr}"
+    );
+}

--- a/crates/cuenv/tests/tui_replay.rs
+++ b/crates/cuenv/tests/tui_replay.rs
@@ -160,6 +160,62 @@ fn cli_tui_replay_rejects_missing_file() {
 }
 
 #[test]
+fn apply_event_is_deterministic_across_replays() {
+    use cuenv::tui::state::{TaskInfo, TaskStatus, TuiState};
+
+    let trace = sample_trace();
+    // The trace exercises both Started/Output/Completed and group lifecycle
+    // events. The model fields touched by `apply_event` should be bit-
+    // identical after two independent replays of the same event stream.
+    #[derive(Debug, PartialEq, Eq)]
+    struct TaskSnapshot {
+        name: String,
+        status: TaskStatus,
+        exit_code: Option<i32>,
+        stdout_lines: usize,
+        stderr_lines: usize,
+    }
+
+    let snapshot = |events: &[CuenvEvent]| -> Vec<TaskSnapshot> {
+        let mut state = TuiState::new();
+        // Register the task so apply_event has somewhere to record output.
+        state.add_task(TaskInfo::new("ci.fmt".to_string(), Vec::new(), 0));
+        for event in events {
+            state.apply_event(event);
+        }
+        let mut snaps: Vec<TaskSnapshot> = state
+            .tasks
+            .iter()
+            .map(|(name, task)| {
+                let output = state.outputs.get(name);
+                TaskSnapshot {
+                    name: name.clone(),
+                    status: task.status,
+                    exit_code: task.exit_code,
+                    stdout_lines: output.map_or(0, |o| o.stdout.len()),
+                    stderr_lines: output.map_or(0, |o| o.stderr.len()),
+                }
+            })
+            .collect();
+        snaps.sort_by(|a, b| a.name.cmp(&b.name));
+        snaps
+    };
+
+    let a = snapshot(&trace);
+    let b = snapshot(&trace);
+    assert_eq!(
+        a, b,
+        "two replays of the same trace must produce identical model state"
+    );
+    assert!(
+        a.iter().any(|s| s.name == "ci.fmt"
+            && s.status == TaskStatus::Completed
+            && s.stdout_lines == 1),
+        "expected ci.fmt to end Completed with one stdout line, got {a:?}"
+    );
+}
+
+#[test]
 fn cli_tui_replay_rejects_empty_recording() {
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("empty.jsonl");

--- a/crates/events/Cargo.toml
+++ b/crates/events/Cargo.toml
@@ -28,8 +28,12 @@ tokio = { workspace = true, features = ["sync", "rt"] }
 uuid = { workspace = true }
 chrono = { workspace = true }
 
+# Errors
+thiserror = { workspace = true }
+
 [dev-dependencies]
 tokio = { workspace = true, features = ["full", "test-util"] }
+tempfile = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/events/src/event.rs
+++ b/crates/events/src/event.rs
@@ -95,12 +95,18 @@ pub enum EventCategory {
 pub enum TaskEvent {
     /// Task execution started.
     Started {
-        /// Task name.
+        /// Task name (fully qualified, e.g. `group.child`).
         name: String,
         /// Command being executed.
         command: String,
         /// Whether this is a hermetic execution.
         hermetic: bool,
+        /// Parent group prefix, if this task runs inside a group.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        parent_group: Option<String>,
+        /// Kind of node — distinguishes leaf tasks from groups/sequences.
+        #[serde(default)]
+        task_kind: TaskKind,
     },
     /// Task cache hit - using cached result.
     CacheHit {
@@ -108,11 +114,59 @@ pub enum TaskEvent {
         name: String,
         /// Cache key that matched.
         cache_key: String,
+        /// Parent group prefix, if applicable.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        parent_group: Option<String>,
     },
     /// Task cache miss - will execute.
     CacheMiss {
         /// Task name.
         name: String,
+        /// Parent group prefix, if applicable.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        parent_group: Option<String>,
+    },
+    /// Task was not eligible for caching.
+    CacheSkipped {
+        /// Task name.
+        name: String,
+        /// Parent group prefix, if applicable.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        parent_group: Option<String>,
+        /// Why caching was skipped for this task.
+        reason: CacheSkipReason,
+    },
+    /// Task is queued — graph picked it but parallelism cap blocks immediate start.
+    Queued {
+        /// Task name.
+        name: String,
+        /// Parent group prefix, if applicable.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        parent_group: Option<String>,
+        /// Position in the ready queue (zero-based).
+        queue_position: usize,
+    },
+    /// Task is being skipped (e.g. dependency failed under continue-on-error).
+    Skipped {
+        /// Task name.
+        name: String,
+        /// Parent group prefix, if applicable.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        parent_group: Option<String>,
+        /// Why the task is skipped.
+        reason: SkipReason,
+    },
+    /// Task is being retried.
+    Retrying {
+        /// Task name.
+        name: String,
+        /// Parent group prefix, if applicable.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        parent_group: Option<String>,
+        /// Attempt number (1-based).
+        attempt: u32,
+        /// Maximum attempts allowed.
+        max_attempts: u32,
     },
     /// Task produced output.
     Output {
@@ -122,6 +176,9 @@ pub enum TaskEvent {
         stream: Stream,
         /// Output content.
         content: String,
+        /// Parent group prefix, if applicable.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        parent_group: Option<String>,
     },
     /// Task execution completed.
     Completed {
@@ -133,6 +190,9 @@ pub enum TaskEvent {
         exit_code: Option<i32>,
         /// Duration in milliseconds.
         duration_ms: u64,
+        /// Parent group prefix, if applicable.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        parent_group: Option<String>,
     },
     /// Task group execution started.
     GroupStarted {
@@ -142,6 +202,12 @@ pub enum TaskEvent {
         sequential: bool,
         /// Number of tasks in the group.
         task_count: usize,
+        /// Parent group prefix when groups nest.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        parent_group: Option<String>,
+        /// Concurrency cap for the group, if set.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        max_concurrency: Option<u32>,
     },
     /// Task group execution completed.
     GroupCompleted {
@@ -151,7 +217,102 @@ pub enum TaskEvent {
         success: bool,
         /// Duration in milliseconds.
         duration_ms: u64,
+        /// Parent group prefix when groups nest.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        parent_group: Option<String>,
+        /// Number of children that succeeded.
+        #[serde(default)]
+        succeeded: usize,
+        /// Number of children that failed.
+        #[serde(default)]
+        failed: usize,
+        /// Number of children that were skipped.
+        #[serde(default)]
+        skipped: usize,
     },
+}
+
+/// Discriminator for the kind of node a task event refers to.
+///
+/// Leaf tasks default to [`TaskKind::Task`]. Group / sequence containers carry
+/// their own group-level events but child task events keep `TaskKind::Task`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TaskKind {
+    /// A leaf task (default).
+    #[default]
+    Task,
+    /// A parallel group of children.
+    Group,
+    /// A sequential list of children.
+    Sequence,
+}
+
+/// Why a task was not eligible for the action cache.
+///
+/// Renderers surface this so users understand why a task ran instead of
+/// being served from cache.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CacheSkipReason {
+    /// Task declared no `inputs` to hash.
+    EmptyInputs,
+    /// Inputs included a non-path reference (project/task ref).
+    NonPathRef,
+    /// Inputs hashed to zero files after resolution.
+    NoResolvedInputs,
+    /// Task carries task-level env vars resolved at execution time.
+    RuntimeEnv,
+    /// Cache was explicitly disabled for this task.
+    Disabled {
+        /// Optional human-readable reason from the cache config.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        reason: Option<String>,
+    },
+    /// Task cache mode is `never`.
+    NeverMode,
+    /// Inputs could not be mapped onto the cache hasher root.
+    HasherRootMismatch,
+    /// Input hashing itself failed.
+    HashFailed,
+}
+
+impl std::fmt::Display for CacheSkipReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::EmptyInputs => write!(f, "empty inputs"),
+            Self::NonPathRef => write!(f, "non-path input"),
+            Self::NoResolvedInputs => write!(f, "no resolved inputs"),
+            Self::RuntimeEnv => write!(f, "runtime env"),
+            Self::Disabled { reason: Some(r) } => write!(f, "disabled: {r}"),
+            Self::Disabled { reason: None } => write!(f, "disabled"),
+            Self::NeverMode => write!(f, "cache mode never"),
+            Self::HasherRootMismatch => write!(f, "hasher root mismatch"),
+            Self::HashFailed => write!(f, "hashing failed"),
+        }
+    }
+}
+
+/// Why a task was skipped at execution time.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum SkipReason {
+    /// A required dependency failed (under continue-on-error mode).
+    DependencyFailed {
+        /// Name of the failing dependency.
+        dep: String,
+    },
+    /// Task was explicitly disabled.
+    ManuallyDisabled,
+}
+
+impl std::fmt::Display for SkipReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::DependencyFailed { dep } => write!(f, "dependency failed: {dep}"),
+            Self::ManuallyDisabled => write!(f, "manually disabled"),
+        }
+    }
 }
 
 /// Service lifecycle events.
@@ -423,6 +584,8 @@ mod tests {
                 name: "build".to_string(),
                 command: "cargo build".to_string(),
                 hermetic: true,
+                parent_group: None,
+                task_kind: TaskKind::Task,
             }),
         );
 
@@ -432,6 +595,23 @@ mod tests {
 
         let parsed: CuenvEvent = serde_json::from_str(&json).unwrap();
         assert_eq!(parsed.id, event.id);
+    }
+
+    #[test]
+    fn test_started_backcompat_serde_no_parent_group() {
+        let json = r#"{"event":"Started","data":{"name":"build","command":"cargo build","hermetic":true}}"#;
+        let parsed: TaskEvent = serde_json::from_str(json).unwrap();
+        match parsed {
+            TaskEvent::Started {
+                parent_group,
+                task_kind,
+                ..
+            } => {
+                assert_eq!(parent_group, None);
+                assert_eq!(task_kind, TaskKind::Task);
+            }
+            _ => panic!("expected Started"),
+        }
     }
 
     #[test]
@@ -455,19 +635,95 @@ mod tests {
         let event = TaskEvent::CacheHit {
             name: "test".to_string(),
             cache_key: "abc123".to_string(),
+            parent_group: Some("ci".to_string()),
         };
         let json = serde_json::to_string(&event).unwrap();
         assert!(json.contains("CacheHit"));
         assert!(json.contains("abc123"));
+        assert!(json.contains("\"parent_group\":\"ci\""));
     }
 
     #[test]
     fn test_task_event_cache_miss() {
         let event = TaskEvent::CacheMiss {
             name: "test".to_string(),
+            parent_group: None,
         };
         let json = serde_json::to_string(&event).unwrap();
         assert!(json.contains("CacheMiss"));
+        // parent_group: None should not be serialized
+        assert!(!json.contains("parent_group"));
+    }
+
+    #[test]
+    fn test_task_event_cache_skipped() {
+        let event = TaskEvent::CacheSkipped {
+            name: "fmt".to_string(),
+            parent_group: None,
+            reason: CacheSkipReason::EmptyInputs,
+        };
+        let json = serde_json::to_string(&event).unwrap();
+        assert!(json.contains("CacheSkipped"));
+        assert!(json.contains("empty_inputs"));
+
+        let parsed: TaskEvent = serde_json::from_str(&json).unwrap();
+        match parsed {
+            TaskEvent::CacheSkipped { reason, .. } => {
+                assert_eq!(reason, CacheSkipReason::EmptyInputs);
+            }
+            _ => panic!("expected CacheSkipped"),
+        }
+    }
+
+    #[test]
+    fn test_task_event_queued() {
+        let event = TaskEvent::Queued {
+            name: "build".to_string(),
+            parent_group: Some("ci".to_string()),
+            queue_position: 3,
+        };
+        let json = serde_json::to_string(&event).unwrap();
+        assert!(json.contains("Queued"));
+        assert!(json.contains("\"queue_position\":3"));
+    }
+
+    #[test]
+    fn test_task_event_skipped_dependency_failed() {
+        let event = TaskEvent::Skipped {
+            name: "deploy".to_string(),
+            parent_group: None,
+            reason: SkipReason::DependencyFailed {
+                dep: "build".to_string(),
+            },
+        };
+        let json = serde_json::to_string(&event).unwrap();
+        assert!(json.contains("Skipped"));
+        let parsed: TaskEvent = serde_json::from_str(&json).unwrap();
+        match parsed {
+            TaskEvent::Skipped { reason, .. } => {
+                assert_eq!(
+                    reason,
+                    SkipReason::DependencyFailed {
+                        dep: "build".to_string()
+                    }
+                );
+            }
+            _ => panic!("expected Skipped"),
+        }
+    }
+
+    #[test]
+    fn test_task_event_retrying() {
+        let event = TaskEvent::Retrying {
+            name: "flaky".to_string(),
+            parent_group: None,
+            attempt: 2,
+            max_attempts: 3,
+        };
+        let json = serde_json::to_string(&event).unwrap();
+        assert!(json.contains("Retrying"));
+        assert!(json.contains("\"attempt\":2"));
+        assert!(json.contains("\"max_attempts\":3"));
     }
 
     #[test]
@@ -476,6 +732,7 @@ mod tests {
             name: "build".to_string(),
             stream: Stream::Stdout,
             content: "compiling...".to_string(),
+            parent_group: None,
         };
         let json = serde_json::to_string(&event).unwrap();
         assert!(json.contains("Output"));
@@ -489,6 +746,7 @@ mod tests {
             success: true,
             exit_code: Some(0),
             duration_ms: 1500,
+            parent_group: None,
         };
         let json = serde_json::to_string(&event).unwrap();
         assert!(json.contains("Completed"));
@@ -501,10 +759,13 @@ mod tests {
             name: "tests".to_string(),
             sequential: false,
             task_count: 5,
+            parent_group: None,
+            max_concurrency: Some(4),
         };
         let json = serde_json::to_string(&event).unwrap();
         assert!(json.contains("GroupStarted"));
         assert!(json.contains('5'));
+        assert!(json.contains("\"max_concurrency\":4"));
     }
 
     #[test]
@@ -513,9 +774,34 @@ mod tests {
             name: "tests".to_string(),
             success: true,
             duration_ms: 3000,
+            parent_group: None,
+            succeeded: 4,
+            failed: 1,
+            skipped: 0,
         };
         let json = serde_json::to_string(&event).unwrap();
         assert!(json.contains("GroupCompleted"));
+        assert!(json.contains("\"succeeded\":4"));
+        assert!(json.contains("\"failed\":1"));
+    }
+
+    #[test]
+    fn test_cache_skip_reason_display() {
+        assert_eq!(format!("{}", CacheSkipReason::EmptyInputs), "empty inputs");
+        assert_eq!(
+            format!(
+                "{}",
+                CacheSkipReason::Disabled {
+                    reason: Some("hermetic".to_string())
+                }
+            ),
+            "disabled: hermetic"
+        );
+    }
+
+    #[test]
+    fn test_task_kind_default() {
+        assert_eq!(TaskKind::default(), TaskKind::Task);
     }
 
     #[test]
@@ -708,6 +994,7 @@ mod tests {
         let categories = vec![
             EventCategory::Task(TaskEvent::CacheMiss {
                 name: "test".to_string(),
+                parent_group: None,
             }),
             EventCategory::Service(ServiceEvent::Pending {
                 name: "db".to_string(),

--- a/crates/events/src/layer.rs
+++ b/crates/events/src/layer.rs
@@ -11,8 +11,9 @@
 )]
 
 use crate::event::{
-    CiEvent, CommandEvent, CuenvEvent, EventCategory, EventSource, InteractiveEvent, OutputEvent,
-    RestartReason, ServiceEvent, Stream, SystemEvent, TaskEvent,
+    CacheSkipReason, CiEvent, CommandEvent, CuenvEvent, EventCategory, EventSource,
+    InteractiveEvent, OutputEvent, RestartReason, ServiceEvent, SkipReason, Stream, SystemEvent,
+    TaskEvent, TaskKind,
 };
 use crate::metadata::correlation_id;
 use crate::redaction::redact;
@@ -80,6 +81,16 @@ struct CuenvEventVisitor {
     duration_ms: Option<u64>,
     sequential: Option<bool>,
     task_count: Option<usize>,
+    parent_group: Option<String>,
+    task_kind: Option<TaskKind>,
+    cache_skip_reason: Option<CacheSkipReason>,
+    skip_reason: Option<SkipReason>,
+    queue_position: Option<usize>,
+    max_attempts: Option<u32>,
+    max_concurrency: Option<u32>,
+    succeeded_count: Option<usize>,
+    failed_count: Option<usize>,
+    skipped_count: Option<usize>,
 
     // Service event fields
     service_name: Option<String>,
@@ -129,6 +140,16 @@ impl CuenvEventVisitor {
             duration_ms: None,
             sequential: None,
             task_count: None,
+            parent_group: None,
+            task_kind: None,
+            cache_skip_reason: None,
+            skip_reason: None,
+            queue_position: None,
+            max_attempts: None,
+            max_concurrency: None,
+            succeeded_count: None,
+            failed_count: None,
+            skipped_count: None,
             service_name: None,
             after_ms: None,
             attempt: None,
@@ -170,34 +191,67 @@ impl CuenvEventVisitor {
                 name: self.task_name?,
                 command: self.command?,
                 hermetic: self.hermetic.unwrap_or(false),
+                parent_group: self.parent_group,
+                task_kind: self.task_kind.unwrap_or_default(),
             }),
             "task.cache_hit" => EventCategory::Task(TaskEvent::CacheHit {
                 name: self.task_name?,
                 cache_key: self.cache_key?,
+                parent_group: self.parent_group,
             }),
             "task.cache_miss" => EventCategory::Task(TaskEvent::CacheMiss {
                 name: self.task_name?,
+                parent_group: self.parent_group,
+            }),
+            "task.cache_skipped" => EventCategory::Task(TaskEvent::CacheSkipped {
+                name: self.task_name?,
+                parent_group: self.parent_group,
+                reason: self.cache_skip_reason?,
+            }),
+            "task.queued" => EventCategory::Task(TaskEvent::Queued {
+                name: self.task_name?,
+                parent_group: self.parent_group,
+                queue_position: self.queue_position.unwrap_or(0),
+            }),
+            "task.skipped" => EventCategory::Task(TaskEvent::Skipped {
+                name: self.task_name?,
+                parent_group: self.parent_group,
+                reason: self.skip_reason?,
+            }),
+            "task.retrying" => EventCategory::Task(TaskEvent::Retrying {
+                name: self.task_name?,
+                parent_group: self.parent_group,
+                attempt: self.attempt.unwrap_or(1),
+                max_attempts: self.max_attempts.unwrap_or(1),
             }),
             "task.output" => EventCategory::Task(TaskEvent::Output {
                 name: self.task_name?,
                 stream: self.stream.unwrap_or(Stream::Stdout),
                 content: content?,
+                parent_group: self.parent_group,
             }),
             "task.completed" => EventCategory::Task(TaskEvent::Completed {
                 name: self.task_name?,
                 success: self.success?,
                 exit_code: self.exit_code,
                 duration_ms: self.duration_ms.unwrap_or(0),
+                parent_group: self.parent_group,
             }),
             "task.group_started" => EventCategory::Task(TaskEvent::GroupStarted {
                 name: self.task_name?,
                 sequential: self.sequential.unwrap_or(false),
                 task_count: self.task_count.unwrap_or(0),
+                parent_group: self.parent_group,
+                max_concurrency: self.max_concurrency,
             }),
             "task.group_completed" => EventCategory::Task(TaskEvent::GroupCompleted {
                 name: self.task_name?,
                 success: self.success?,
                 duration_ms: self.duration_ms.unwrap_or(0),
+                parent_group: self.parent_group,
+                succeeded: self.succeeded_count.unwrap_or(0),
+                failed: self.failed_count.unwrap_or(0),
+                skipped: self.skipped_count.unwrap_or(0),
             }),
 
             // Service events
@@ -359,6 +413,20 @@ impl Visit for CuenvEventVisitor {
                     _ => None,
                 };
             }
+            "task_kind" => {
+                self.task_kind = match value {
+                    "task" => Some(TaskKind::Task),
+                    "group" => Some(TaskKind::Group),
+                    "sequence" => Some(TaskKind::Sequence),
+                    _ => None,
+                };
+            }
+            "cache_skip_reason" => {
+                self.cache_skip_reason = serde_json::from_str(value).ok();
+            }
+            "skip_reason" => {
+                self.skip_reason = serde_json::from_str(value).ok();
+            }
             _ => {}
         }
     }
@@ -369,8 +437,14 @@ impl Visit for CuenvEventVisitor {
             "duration_ms" => self.duration_ms = Some(value as u64),
             "after_ms" => self.after_ms = Some(value as u64),
             "attempt" => self.attempt = Some(value as u32),
+            "max_attempts" => self.max_attempts = Some(value as u32),
             "count" => self.count = Some(value as usize),
             "task_count" => self.task_count = Some(value as usize),
+            "queue_position" => self.queue_position = Some(value as usize),
+            "max_concurrency" => self.max_concurrency = Some(value as u32),
+            "succeeded" => self.succeeded_count = Some(value as usize),
+            "failed_count" => self.failed_count = Some(value as usize),
+            "skipped_count" => self.skipped_count = Some(value as usize),
             "elapsed_secs" => self.elapsed_secs = Some(value as u64),
             _ => {}
         }
@@ -381,8 +455,14 @@ impl Visit for CuenvEventVisitor {
             "duration_ms" => self.duration_ms = Some(value),
             "after_ms" => self.after_ms = Some(value),
             "attempt" => self.attempt = Some(value as u32),
+            "max_attempts" => self.max_attempts = Some(value as u32),
             "count" => self.count = Some(value as usize),
             "task_count" => self.task_count = Some(value as usize),
+            "queue_position" => self.queue_position = Some(value as usize),
+            "max_concurrency" => self.max_concurrency = Some(value as u32),
+            "succeeded" => self.succeeded_count = Some(value as usize),
+            "failed_count" => self.failed_count = Some(value as usize),
+            "skipped_count" => self.skipped_count = Some(value as usize),
             "elapsed_secs" => self.elapsed_secs = Some(value),
             _ => {}
         }
@@ -427,7 +507,7 @@ impl Visit for CuenvEventVisitor {
             // When tracing uses Display formatting (%), it wraps values in a DisplayValue
             // which then gets passed to record_debug instead of record_str
             "event_type" | "task_name" | "service_name" | "name" | "command" | "cmd"
-            | "content" | "cache_key" | "stream" | "error" | "reason" => {
+            | "content" | "cache_key" | "stream" | "error" | "reason" | "task_kind" => {
                 // Remove surrounding quotes if present (debug format adds them for strings)
                 let cleaned = value_str.trim_matches('"');
                 match field.name() {
@@ -446,8 +526,32 @@ impl Visit for CuenvEventVisitor {
                             _ => None,
                         };
                     }
+                    "task_kind" => {
+                        self.task_kind = match cleaned {
+                            "task" => Some(TaskKind::Task),
+                            "group" => Some(TaskKind::Group),
+                            "sequence" => Some(TaskKind::Sequence),
+                            _ => None,
+                        };
+                    }
                     _ => {}
                 }
+            }
+            // The cache_skip_reason and skip_reason fields carry JSON-encoded
+            // enum values via Display formatting (%). When the JSON itself is
+            // already-quoted (e.g. unit variant `"empty_inputs"`) we must not
+            // strip the quotes — serde_json needs them to deserialize.
+            "cache_skip_reason" => {
+                let cleaned = value_str.trim_matches('"');
+                self.cache_skip_reason = serde_json::from_str(cleaned)
+                    .ok()
+                    .or_else(|| serde_json::from_str(&value_str).ok());
+            }
+            "skip_reason" => {
+                let cleaned = value_str.trim_matches('"');
+                self.skip_reason = serde_json::from_str(cleaned)
+                    .ok()
+                    .or_else(|| serde_json::from_str(&value_str).ok());
             }
             // Handle exit_code which uses Debug formatting (?exit_code)
             // Can be "Some(0)", "None", or just "0" depending on context
@@ -466,9 +570,37 @@ impl Visit for CuenvEventVisitor {
                     }
                 }
             }
+            // parent_group uses Debug (?parent_group) since the macro accepts
+            // Option<impl Display> and that doesn't itself impl Display.
+            // Format is `Some("ci")`, `None`, or `Some(ci)` depending on
+            // whether the inner value impls Debug as a quoted string.
+            "parent_group" => {
+                self.parent_group = parse_optional_debug_str(&value_str);
+            }
+            // max_concurrency uses ?max_concurrency (Option<u32>).
+            "max_concurrency" => {
+                if let Some(inner) = value_str
+                    .strip_prefix("Some(")
+                    .and_then(|s| s.strip_suffix(')'))
+                    && let Ok(n) = inner.parse::<u32>()
+                {
+                    self.max_concurrency = Some(n);
+                }
+            }
             _ => {}
         }
     }
+}
+
+/// Parse a Rust-`Debug`-formatted `Option<impl Debug>` containing a string.
+///
+/// Handles `Some("foo")`, `Some(foo)`, and `None`.
+fn parse_optional_debug_str(value: &str) -> Option<String> {
+    if value == "None" {
+        return None;
+    }
+    let inner = value.strip_prefix("Some(")?.strip_suffix(')')?;
+    Some(inner.trim_matches('"').to_string())
 }
 
 #[cfg(test)]
@@ -547,12 +679,77 @@ mod tests {
                 name,
                 command,
                 hermetic,
+                ..
             }) => {
                 assert_eq!(name, "build");
                 assert_eq!(command, "cargo build");
                 assert!(hermetic);
             }
             _ => panic!("Expected task started event"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_layer_extracts_parent_group_and_task_kind() {
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let layer = CuenvEventLayer::new(tx);
+        let subscriber = tracing_subscriber::registry().with(layer);
+
+        tracing::subscriber::with_default(subscriber, || {
+            let parent: Option<&str> = Some("ci");
+            tracing::info!(
+                target: "cuenv::task",
+                event_type = "task.started",
+                task_name = "ci.build",
+                command = "cargo build",
+                hermetic = true,
+                parent_group = ?parent,
+                task_kind = "task",
+                "Task started in group"
+            );
+        });
+
+        let event = rx.recv().await.unwrap();
+        match event.category {
+            EventCategory::Task(TaskEvent::Started {
+                name,
+                parent_group,
+                task_kind,
+                ..
+            }) => {
+                assert_eq!(name, "ci.build");
+                assert_eq!(parent_group.as_deref(), Some("ci"));
+                assert_eq!(task_kind, TaskKind::Task);
+            }
+            other => panic!("Expected task started event, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_layer_extracts_cache_skipped() {
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let layer = CuenvEventLayer::new(tx);
+        let subscriber = tracing_subscriber::registry().with(layer);
+
+        tracing::subscriber::with_default(subscriber, || {
+            let reason = CacheSkipReason::EmptyInputs;
+            let encoded = serde_json::to_string(&reason).unwrap();
+            tracing::info!(
+                target: "cuenv::task",
+                event_type = "task.cache_skipped",
+                task_name = "fmt",
+                cache_skip_reason = %encoded,
+                "skipped"
+            );
+        });
+
+        let event = rx.recv().await.unwrap();
+        match event.category {
+            EventCategory::Task(TaskEvent::CacheSkipped { name, reason, .. }) => {
+                assert_eq!(name, "fmt");
+                assert_eq!(reason, CacheSkipReason::EmptyInputs);
+            }
+            other => panic!("Expected cache skipped event, got {other:?}"),
         }
     }
 }

--- a/crates/events/src/lib.rs
+++ b/crates/events/src/lib.rs
@@ -53,7 +53,7 @@ pub use event::{
 pub use layer::CuenvEventLayer;
 pub use metadata::{MetadataContext, correlation_id, set_correlation_id};
 pub use redaction::{REDACTED_PLACEHOLDER, redact, register_secret, register_secrets};
-pub use renderers::{CliRenderer, JsonRenderer};
+pub use renderers::{CliRenderer, EventRecorder, EventReplayReader, JsonRenderer, RecorderError};
 
 // ============================================================================
 // Emit Macros

--- a/crates/events/src/lib.rs
+++ b/crates/events/src/lib.rs
@@ -46,8 +46,9 @@ pub mod renderers;
 // Re-exports for convenience
 pub use bus::{EventBus, EventReceiver, EventSender, SendError};
 pub use event::{
-    CiEvent, CommandEvent, CuenvEvent, EventCategory, EventSource, InteractiveEvent, OutputEvent,
-    RestartReason, ServiceEvent, Stream, SystemEvent, TaskEvent,
+    CacheSkipReason, CiEvent, CommandEvent, CuenvEvent, EventCategory, EventSource,
+    InteractiveEvent, OutputEvent, RestartReason, ServiceEvent, SkipReason, Stream, SystemEvent,
+    TaskEvent, TaskKind,
 };
 pub use layer::CuenvEventLayer;
 pub use metadata::{MetadataContext, correlation_id, set_correlation_id};
@@ -60,10 +61,12 @@ pub use renderers::{CliRenderer, JsonRenderer};
 
 /// Emit a task started event.
 ///
-/// # Example
-/// ```rust,ignore
-/// emit_task_started!("build", "cargo build", true);
-/// ```
+/// Two forms are supported:
+/// - `emit_task_started!(name, command, hermetic)` — leaf task, no group.
+/// - `emit_task_started!(name, command, hermetic, parent_group, task_kind)`
+///   — leaf or group task, optionally inside a parent group.
+///   `parent_group` is `Option<&str>` (or anything `Display`); `task_kind`
+///   is a `&'static str` matching `TaskKind` (`"task"`, `"group"`, `"sequence"`).
 #[macro_export]
 macro_rules! emit_task_started {
     ($name:expr, $command:expr, $hermetic:expr) => {
@@ -75,14 +78,24 @@ macro_rules! emit_task_started {
             hermetic = $hermetic,
         )
     };
+    ($name:expr, $command:expr, $hermetic:expr, $parent_group:expr, $task_kind:expr) => {
+        ::tracing::info!(
+            target: "cuenv::task",
+            event_type = "task.started",
+            task_name = %$name,
+            command = %$command,
+            hermetic = $hermetic,
+            parent_group = ?$parent_group,
+            task_kind = $task_kind,
+        )
+    };
 }
 
 /// Emit a task cache hit event.
 ///
-/// # Example
-/// ```rust,ignore
-/// emit_task_cache_hit!("build", "abc123");
-/// ```
+/// Forms:
+/// - `emit_task_cache_hit!(name, cache_key)`
+/// - `emit_task_cache_hit!(name, cache_key, parent_group)`
 #[macro_export]
 macro_rules! emit_task_cache_hit {
     ($name:expr, $cache_key:expr) => {
@@ -93,9 +106,22 @@ macro_rules! emit_task_cache_hit {
             cache_key = %$cache_key,
         )
     };
+    ($name:expr, $cache_key:expr, $parent_group:expr) => {
+        ::tracing::info!(
+            target: "cuenv::task",
+            event_type = "task.cache_hit",
+            task_name = %$name,
+            cache_key = %$cache_key,
+            parent_group = ?$parent_group,
+        )
+    };
 }
 
 /// Emit a task cache miss event.
+///
+/// Forms:
+/// - `emit_task_cache_miss!(name)`
+/// - `emit_task_cache_miss!(name, parent_group)`
 #[macro_export]
 macro_rules! emit_task_cache_miss {
     ($name:expr) => {
@@ -105,14 +131,131 @@ macro_rules! emit_task_cache_miss {
             task_name = %$name,
         )
     };
+    ($name:expr, $parent_group:expr) => {
+        ::tracing::info!(
+            target: "cuenv::task",
+            event_type = "task.cache_miss",
+            task_name = %$name,
+            parent_group = ?$parent_group,
+        )
+    };
+}
+
+/// Emit a task cache skipped event with a structured reason.
+///
+/// `reason` should be a [`crate::CacheSkipReason`].
+///
+/// Forms:
+/// - `emit_task_cache_skipped!(name, reason)`
+/// - `emit_task_cache_skipped!(name, reason, parent_group)`
+#[macro_export]
+macro_rules! emit_task_cache_skipped {
+    ($name:expr, $reason:expr) => {
+        ::tracing::info!(
+            target: "cuenv::task",
+            event_type = "task.cache_skipped",
+            task_name = %$name,
+            cache_skip_reason = %$crate::__macro_helpers::encode_cache_skip_reason(&$reason),
+        )
+    };
+    ($name:expr, $reason:expr, $parent_group:expr) => {
+        ::tracing::info!(
+            target: "cuenv::task",
+            event_type = "task.cache_skipped",
+            task_name = %$name,
+            cache_skip_reason = %$crate::__macro_helpers::encode_cache_skip_reason(&$reason),
+            parent_group = ?$parent_group,
+        )
+    };
+}
+
+/// Emit a task queued event (graph picked task but parallelism cap blocks start).
+///
+/// Forms:
+/// - `emit_task_queued!(name, queue_position)`
+/// - `emit_task_queued!(name, queue_position, parent_group)`
+#[macro_export]
+macro_rules! emit_task_queued {
+    ($name:expr, $queue_position:expr) => {
+        ::tracing::info!(
+            target: "cuenv::task",
+            event_type = "task.queued",
+            task_name = %$name,
+            queue_position = $queue_position,
+        )
+    };
+    ($name:expr, $queue_position:expr, $parent_group:expr) => {
+        ::tracing::info!(
+            target: "cuenv::task",
+            event_type = "task.queued",
+            task_name = %$name,
+            queue_position = $queue_position,
+            parent_group = ?$parent_group,
+        )
+    };
+}
+
+/// Emit a task skipped event with a structured reason.
+///
+/// `reason` should be a [`crate::SkipReason`].
+///
+/// Forms:
+/// - `emit_task_skipped!(name, reason)`
+/// - `emit_task_skipped!(name, reason, parent_group)`
+#[macro_export]
+macro_rules! emit_task_skipped {
+    ($name:expr, $reason:expr) => {
+        ::tracing::info!(
+            target: "cuenv::task",
+            event_type = "task.skipped",
+            task_name = %$name,
+            skip_reason = %$crate::__macro_helpers::encode_skip_reason(&$reason),
+        )
+    };
+    ($name:expr, $reason:expr, $parent_group:expr) => {
+        ::tracing::info!(
+            target: "cuenv::task",
+            event_type = "task.skipped",
+            task_name = %$name,
+            skip_reason = %$crate::__macro_helpers::encode_skip_reason(&$reason),
+            parent_group = ?$parent_group,
+        )
+    };
+}
+
+/// Emit a task retrying event.
+///
+/// Forms:
+/// - `emit_task_retrying!(name, attempt, max_attempts)`
+/// - `emit_task_retrying!(name, attempt, max_attempts, parent_group)`
+#[macro_export]
+macro_rules! emit_task_retrying {
+    ($name:expr, $attempt:expr, $max_attempts:expr) => {
+        ::tracing::info!(
+            target: "cuenv::task",
+            event_type = "task.retrying",
+            task_name = %$name,
+            attempt = $attempt,
+            max_attempts = $max_attempts,
+        )
+    };
+    ($name:expr, $attempt:expr, $max_attempts:expr, $parent_group:expr) => {
+        ::tracing::info!(
+            target: "cuenv::task",
+            event_type = "task.retrying",
+            task_name = %$name,
+            attempt = $attempt,
+            max_attempts = $max_attempts,
+            parent_group = ?$parent_group,
+        )
+    };
 }
 
 /// Emit a task output event.
 ///
-/// # Example
-/// ```rust,ignore
-/// emit_task_output!("build", "stdout", "Compiling...");
-/// ```
+/// Forms:
+/// - `emit_task_output!(name, stream, content)`
+/// - `emit_task_output!(name, stream, content, parent_group)`
 #[macro_export]
 macro_rules! emit_task_output {
     ($name:expr, $stream:expr, $content:expr) => {
@@ -124,14 +267,23 @@ macro_rules! emit_task_output {
             content = %$content,
         )
     };
+    ($name:expr, $stream:expr, $content:expr, $parent_group:expr) => {
+        ::tracing::info!(
+            target: "cuenv::task",
+            event_type = "task.output",
+            task_name = %$name,
+            stream = $stream,
+            content = %$content,
+            parent_group = ?$parent_group,
+        )
+    };
 }
 
 /// Emit a task completed event.
 ///
-/// # Example
-/// ```rust,ignore
-/// emit_task_completed!("build", true, Some(0), 1234);
-/// ```
+/// Forms:
+/// - `emit_task_completed!(name, success, exit_code, duration_ms)`
+/// - `emit_task_completed!(name, success, exit_code, duration_ms, parent_group)`
 #[macro_export]
 macro_rules! emit_task_completed {
     ($name:expr, $success:expr, $exit_code:expr, $duration_ms:expr) => {
@@ -144,9 +296,24 @@ macro_rules! emit_task_completed {
             duration_ms = $duration_ms,
         )
     };
+    ($name:expr, $success:expr, $exit_code:expr, $duration_ms:expr, $parent_group:expr) => {
+        ::tracing::info!(
+            target: "cuenv::task",
+            event_type = "task.completed",
+            task_name = %$name,
+            success = $success,
+            exit_code = ?$exit_code,
+            duration_ms = $duration_ms,
+            parent_group = ?$parent_group,
+        )
+    };
 }
 
 /// Emit a task group started event.
+///
+/// Forms:
+/// - `emit_task_group_started!(name, sequential, task_count)`
+/// - `emit_task_group_started!(name, sequential, task_count, parent_group, max_concurrency)`
 #[macro_export]
 macro_rules! emit_task_group_started {
     ($name:expr, $sequential:expr, $task_count:expr) => {
@@ -158,9 +325,25 @@ macro_rules! emit_task_group_started {
             task_count = $task_count,
         )
     };
+    ($name:expr, $sequential:expr, $task_count:expr, $parent_group:expr, $max_concurrency:expr) => {
+        ::tracing::info!(
+            target: "cuenv::task",
+            event_type = "task.group_started",
+            task_name = %$name,
+            sequential = $sequential,
+            task_count = $task_count,
+            parent_group = ?$parent_group,
+            max_concurrency = ?$max_concurrency,
+        )
+    };
 }
 
 /// Emit a task group completed event.
+///
+/// Forms:
+/// - `emit_task_group_completed!(name, success, duration_ms)`
+/// - `emit_task_group_completed!(name, success, duration_ms, succeeded, failed, skipped)`
+/// - `emit_task_group_completed!(name, success, duration_ms, succeeded, failed, skipped, parent_group)`
 #[macro_export]
 macro_rules! emit_task_group_completed {
     ($name:expr, $success:expr, $duration_ms:expr) => {
@@ -170,6 +353,31 @@ macro_rules! emit_task_group_completed {
             task_name = %$name,
             success = $success,
             duration_ms = $duration_ms,
+        )
+    };
+    ($name:expr, $success:expr, $duration_ms:expr, $succeeded:expr, $failed:expr, $skipped:expr) => {
+        ::tracing::info!(
+            target: "cuenv::task",
+            event_type = "task.group_completed",
+            task_name = %$name,
+            success = $success,
+            duration_ms = $duration_ms,
+            succeeded = $succeeded,
+            failed_count = $failed,
+            skipped_count = $skipped,
+        )
+    };
+    ($name:expr, $success:expr, $duration_ms:expr, $succeeded:expr, $failed:expr, $skipped:expr, $parent_group:expr) => {
+        ::tracing::info!(
+            target: "cuenv::task",
+            event_type = "task.group_completed",
+            task_name = %$name,
+            success = $success,
+            duration_ms = $duration_ms,
+            succeeded = $succeeded,
+            failed_count = $failed,
+            skipped_count = $skipped,
+            parent_group = ?$parent_group,
         )
     };
 }
@@ -602,6 +810,27 @@ macro_rules! emit_stderr {
     };
 }
 
+/// Internal helpers used by the `emit_*!` macros.
+///
+/// Not part of the stable public API — exposed only because exported macros
+/// must reference it via `$crate`.
+#[doc(hidden)]
+pub mod __macro_helpers {
+    use crate::event::{CacheSkipReason, SkipReason};
+
+    /// Serialize a [`CacheSkipReason`] to JSON for tracing field transport.
+    #[must_use]
+    pub fn encode_cache_skip_reason(reason: &CacheSkipReason) -> String {
+        serde_json::to_string(reason).unwrap_or_default()
+    }
+
+    /// Serialize a [`SkipReason`] to JSON for tracing field transport.
+    #[must_use]
+    pub fn encode_skip_reason(reason: &SkipReason) -> String {
+        serde_json::to_string(reason).unwrap_or_default()
+    }
+}
+
 /// Print to stdout with automatic secret redaction (with newline).
 ///
 /// Use this instead of `println!` when output might contain secrets.
@@ -644,6 +873,40 @@ mod tests {
             emit_task_completed!("build", true, Some(0), 1000_u64);
             emit_task_group_started!("all", false, 3_usize);
             emit_task_group_completed!("all", true, 5000_u64);
+        });
+    }
+
+    #[tokio::test]
+    async fn test_task_macros_extended_forms_compile() {
+        use crate::event::{CacheSkipReason, SkipReason, TaskKind};
+        with_test_subscriber(|| {
+            let parent: Option<&str> = Some("ci");
+            emit_task_started!("ci.build", "cargo build", true, parent, "task");
+            let _ = TaskKind::Task;
+            emit_task_cache_hit!("ci.build", "abc123", parent);
+            emit_task_cache_miss!("ci.test", parent);
+            emit_task_cache_skipped!("ci.fmt", CacheSkipReason::EmptyInputs, parent);
+            emit_task_queued!("ci.lint", 2_usize, parent);
+            emit_task_skipped!(
+                "ci.deploy",
+                SkipReason::DependencyFailed {
+                    dep: "ci.build".to_string()
+                },
+                parent
+            );
+            emit_task_retrying!("ci.flaky", 2_u32, 3_u32, parent);
+            emit_task_output!("ci.build", "stdout", "out", parent);
+            emit_task_completed!("ci.build", true, Some(0), 1000_u64, parent);
+            emit_task_group_started!("ci", false, 3_usize, None::<&str>, Some(4_u32));
+            emit_task_group_completed!(
+                "ci",
+                true,
+                5000_u64,
+                3_usize,
+                0_usize,
+                0_usize,
+                None::<&str>
+            );
         });
     }
 

--- a/crates/events/src/renderers/cli.rs
+++ b/crates/events/src/renderers/cli.rs
@@ -86,6 +86,7 @@ impl CliRenderer {
                 name,
                 command,
                 hermetic,
+                ..
             } => {
                 let hermetic_indicator = if *hermetic { " (hermetic)" } else { "" };
                 eprintln!("> [{name}] {command}{hermetic_indicator}");
@@ -93,10 +94,35 @@ impl CliRenderer {
             TaskEvent::CacheHit { name, .. } => {
                 eprintln!("> [{name}] (cached)");
             }
-            TaskEvent::CacheMiss { name } => {
+            TaskEvent::CacheMiss { name, .. } => {
                 if self.config.verbose {
                     eprintln!("> [{name}] cache miss, executing...");
                 }
+            }
+            TaskEvent::CacheSkipped { name, reason, .. } => {
+                if self.config.verbose {
+                    eprintln!("> [{name}] cache skipped: {reason}");
+                }
+            }
+            TaskEvent::Queued {
+                name,
+                queue_position,
+                ..
+            } => {
+                if self.config.verbose {
+                    eprintln!("> [{name}] queued (position {queue_position})");
+                }
+            }
+            TaskEvent::Skipped { name, reason, .. } => {
+                eprintln!("> [{name}] skipped ({reason})");
+            }
+            TaskEvent::Retrying {
+                name,
+                attempt,
+                max_attempts,
+                ..
+            } => {
+                eprintln!("> [{name}] retrying (attempt {attempt}/{max_attempts})");
             }
             TaskEvent::Output {
                 stream, content, ..
@@ -123,6 +149,7 @@ impl CliRenderer {
                 name,
                 sequential,
                 task_count,
+                ..
             } => {
                 let mode = if *sequential {
                     "sequential"
@@ -135,10 +162,16 @@ impl CliRenderer {
                 name,
                 success,
                 duration_ms,
+                succeeded,
+                failed,
+                skipped,
+                ..
             } => {
                 if self.config.verbose {
                     let status = if *success { "completed" } else { "failed" };
-                    eprintln!("> Group {name} {status} in {duration_ms}ms");
+                    eprintln!(
+                        "> Group {name} {status} in {duration_ms}ms ({succeeded} ok, {failed} failed, {skipped} skipped)"
+                    );
                 }
             }
         }
@@ -398,6 +431,8 @@ mod tests {
             name: "test-task".to_string(),
             command: "echo hello".to_string(),
             hermetic: false,
+            parent_group: None,
+            task_kind: crate::event::TaskKind::Task,
         }));
         renderer.render(&event);
     }
@@ -409,6 +444,8 @@ mod tests {
             name: "test-task".to_string(),
             command: "echo hello".to_string(),
             hermetic: true,
+            parent_group: None,
+            task_kind: crate::event::TaskKind::Task,
         }));
         renderer.render(&event);
     }
@@ -419,6 +456,7 @@ mod tests {
         let event = make_event(EventCategory::Task(TaskEvent::CacheHit {
             name: "cached-task".to_string(),
             cache_key: "abc123".to_string(),
+            parent_group: None,
         }));
         renderer.render(&event);
     }
@@ -432,6 +470,62 @@ mod tests {
         let renderer = CliRenderer::with_config(config);
         let event = make_event(EventCategory::Task(TaskEvent::CacheMiss {
             name: "uncached-task".to_string(),
+            parent_group: None,
+        }));
+        renderer.render(&event);
+    }
+
+    #[test]
+    fn test_render_task_cache_skipped_verbose() {
+        let config = CliRendererConfig {
+            colors: false,
+            verbose: true,
+        };
+        let renderer = CliRenderer::with_config(config);
+        let event = make_event(EventCategory::Task(TaskEvent::CacheSkipped {
+            name: "fmt".to_string(),
+            parent_group: None,
+            reason: crate::event::CacheSkipReason::EmptyInputs,
+        }));
+        renderer.render(&event);
+    }
+
+    #[test]
+    fn test_render_task_skipped() {
+        let renderer = CliRenderer::new();
+        let event = make_event(EventCategory::Task(TaskEvent::Skipped {
+            name: "deploy".to_string(),
+            parent_group: None,
+            reason: crate::event::SkipReason::DependencyFailed {
+                dep: "build".to_string(),
+            },
+        }));
+        renderer.render(&event);
+    }
+
+    #[test]
+    fn test_render_task_queued_verbose() {
+        let config = CliRendererConfig {
+            colors: false,
+            verbose: true,
+        };
+        let renderer = CliRenderer::with_config(config);
+        let event = make_event(EventCategory::Task(TaskEvent::Queued {
+            name: "build".to_string(),
+            parent_group: None,
+            queue_position: 1,
+        }));
+        renderer.render(&event);
+    }
+
+    #[test]
+    fn test_render_task_retrying() {
+        let renderer = CliRenderer::new();
+        let event = make_event(EventCategory::Task(TaskEvent::Retrying {
+            name: "flaky".to_string(),
+            parent_group: None,
+            attempt: 2,
+            max_attempts: 3,
         }));
         renderer.render(&event);
     }
@@ -443,6 +537,7 @@ mod tests {
             name: "task".to_string(),
             stream: Stream::Stdout,
             content: "stdout content".to_string(),
+            parent_group: None,
         }));
         renderer.render(&event);
     }
@@ -454,6 +549,7 @@ mod tests {
             name: "task".to_string(),
             stream: Stream::Stderr,
             content: "stderr content".to_string(),
+            parent_group: None,
         }));
         renderer.render(&event);
     }
@@ -470,6 +566,7 @@ mod tests {
             success: true,
             exit_code: Some(0),
             duration_ms: 1000,
+            parent_group: None,
         }));
         renderer.render(&event);
     }
@@ -486,6 +583,7 @@ mod tests {
             success: false,
             exit_code: Some(1),
             duration_ms: 500,
+            parent_group: None,
         }));
         renderer.render(&event);
     }
@@ -497,6 +595,8 @@ mod tests {
             name: "group".to_string(),
             sequential: true,
             task_count: 5,
+            parent_group: None,
+            max_concurrency: None,
         }));
         renderer.render(&event);
     }
@@ -508,6 +608,8 @@ mod tests {
             name: "group".to_string(),
             sequential: false,
             task_count: 3,
+            parent_group: None,
+            max_concurrency: Some(4),
         }));
         renderer.render(&event);
     }
@@ -523,6 +625,10 @@ mod tests {
             name: "group".to_string(),
             success: true,
             duration_ms: 2000,
+            parent_group: None,
+            succeeded: 3,
+            failed: 0,
+            skipped: 0,
         }));
         renderer.render(&event);
     }

--- a/crates/events/src/renderers/mod.rs
+++ b/crates/events/src/renderers/mod.rs
@@ -4,6 +4,8 @@
 
 pub mod cli;
 pub mod json;
+pub mod recorder;
 
 pub use cli::CliRenderer;
 pub use json::JsonRenderer;
+pub use recorder::{EventRecorder, EventReplayReader, RecorderError};

--- a/crates/events/src/renderers/recorder.rs
+++ b/crates/events/src/renderers/recorder.rs
@@ -1,0 +1,258 @@
+//! Event recorder for cuenv events.
+//!
+//! Writes every event to a file as JSON Lines (one event per line). Pairs
+//! with the `tui-replay` subcommand to deterministically replay captured
+//! traces — useful for TUI snapshot testing and post-mortem analysis.
+
+use crate::bus::EventReceiver;
+use crate::event::{CuenvEvent, EventCategory, SystemEvent};
+use std::fs::File;
+use std::io::{self, BufWriter, Write};
+use std::path::{Path, PathBuf};
+
+/// Errors that can occur while recording events.
+#[derive(thiserror::Error, Debug)]
+pub enum RecorderError {
+    /// Failed to create the destination file.
+    #[error("failed to create event recording at {path}: {source}")]
+    Create {
+        /// Path that failed to open.
+        path: PathBuf,
+        /// Underlying I/O error.
+        #[source]
+        source: io::Error,
+    },
+}
+
+/// Writes events to a file as JSON Lines for later replay.
+///
+/// Each line is a single serialized [`CuenvEvent`] terminated by `\n`.
+/// The recorder stops cleanly on [`SystemEvent::Shutdown`] and flushes the
+/// underlying writer on drop.
+#[derive(Debug)]
+pub struct EventRecorder {
+    writer: BufWriter<File>,
+    path: PathBuf,
+    events_written: u64,
+}
+
+impl EventRecorder {
+    /// Create a new recorder writing to `path`.
+    ///
+    /// Truncates any existing file. Parent directories are not created
+    /// automatically — callers should ensure the directory exists.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RecorderError::Create`] if the file cannot be opened.
+    pub fn create(path: impl Into<PathBuf>) -> Result<Self, RecorderError> {
+        let path = path.into();
+        let file = File::create(&path).map_err(|source| RecorderError::Create {
+            path: path.clone(),
+            source,
+        })?;
+        Ok(Self {
+            writer: BufWriter::new(file),
+            path,
+            events_written: 0,
+        })
+    }
+
+    /// Path the recorder is writing to.
+    #[must_use]
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// Number of events written so far.
+    #[must_use]
+    pub const fn events_written(&self) -> u64 {
+        self.events_written
+    }
+
+    /// Write a single event as a JSON line.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`io::Error`] if the underlying writer fails. Serialization
+    /// failures are converted to `io::ErrorKind::InvalidData`.
+    pub fn write_event(&mut self, event: &CuenvEvent) -> io::Result<()> {
+        let line = serde_json::to_string(event)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+        self.writer.write_all(line.as_bytes())?;
+        self.writer.write_all(b"\n")?;
+        self.events_written += 1;
+        Ok(())
+    }
+
+    /// Consume events from the receiver until [`SystemEvent::Shutdown`].
+    ///
+    /// I/O errors are surfaced via `tracing::warn!` so a recorder failure
+    /// never crashes the host process. The receiver still drains to keep
+    /// the broadcast bus from lagging.
+    pub async fn run(mut self, mut receiver: EventReceiver) {
+        while let Some(event) = receiver.recv().await {
+            if let Err(err) = self.write_event(&event) {
+                tracing::warn!(
+                    path = %self.path.display(),
+                    error = %err,
+                    "event recorder write failed; recording will be incomplete"
+                );
+            }
+            if matches!(event.category, EventCategory::System(SystemEvent::Shutdown)) {
+                break;
+            }
+        }
+        if let Err(err) = self.writer.flush() {
+            tracing::warn!(
+                path = %self.path.display(),
+                error = %err,
+                "event recorder flush failed; recording may be truncated"
+            );
+        }
+    }
+}
+
+/// Iterator over events recorded by [`EventRecorder`].
+///
+/// Reads a JSONL file produced by an `EventRecorder` and yields each event.
+/// Use this from the replay subcommand to drive a TUI deterministically.
+pub struct EventReplayReader {
+    lines: std::io::Lines<std::io::BufReader<File>>,
+}
+
+impl EventReplayReader {
+    /// Open the recording at `path` for replay.
+    ///
+    /// # Errors
+    ///
+    /// Returns the underlying [`io::Error`] if the file cannot be opened.
+    pub fn open(path: impl AsRef<Path>) -> io::Result<Self> {
+        use std::io::BufRead;
+        let file = File::open(path.as_ref())?;
+        let reader = std::io::BufReader::new(file);
+        Ok(Self {
+            lines: reader.lines(),
+        })
+    }
+}
+
+impl Iterator for EventReplayReader {
+    type Item = io::Result<CuenvEvent>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let line = self.lines.next()?;
+        Some(line.and_then(|raw| {
+            serde_json::from_str::<CuenvEvent>(&raw)
+                .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
+        }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::event::{EventCategory, EventSource, OutputEvent, TaskEvent, TaskKind};
+    use tempfile::tempdir;
+    use uuid::Uuid;
+
+    fn make_event(category: EventCategory) -> CuenvEvent {
+        CuenvEvent::new(Uuid::new_v4(), EventSource::new("test::target"), category)
+    }
+
+    #[test]
+    fn write_and_read_round_trip() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("trace.jsonl");
+
+        let started = make_event(EventCategory::Task(TaskEvent::Started {
+            name: "ci.build".to_string(),
+            command: "cargo build".to_string(),
+            hermetic: true,
+            parent_group: Some("ci".to_string()),
+            task_kind: TaskKind::Task,
+        }));
+        let completed = make_event(EventCategory::Task(TaskEvent::Completed {
+            name: "ci.build".to_string(),
+            success: true,
+            exit_code: Some(0),
+            duration_ms: 1234,
+            parent_group: Some("ci".to_string()),
+        }));
+
+        {
+            let mut recorder = EventRecorder::create(&path).unwrap();
+            recorder.write_event(&started).unwrap();
+            recorder.write_event(&completed).unwrap();
+            assert_eq!(recorder.events_written(), 2);
+            recorder.writer.flush().unwrap();
+        }
+
+        let events: Vec<CuenvEvent> = EventReplayReader::open(&path)
+            .unwrap()
+            .collect::<io::Result<Vec<_>>>()
+            .unwrap();
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0].id, started.id);
+        assert_eq!(events[1].id, completed.id);
+    }
+
+    #[test]
+    fn replay_reader_surfaces_corrupt_lines() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("bad.jsonl");
+        std::fs::write(&path, "{not valid json}\n").unwrap();
+
+        let mut reader = EventReplayReader::open(&path).unwrap();
+        let first = reader.next().expect("one entry");
+        assert!(first.is_err());
+    }
+
+    #[test]
+    fn skips_no_events_with_empty_file() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("empty.jsonl");
+        let _ = EventRecorder::create(&path).unwrap();
+
+        let events: Vec<_> = EventReplayReader::open(&path)
+            .unwrap()
+            .collect::<io::Result<Vec<_>>>()
+            .unwrap();
+        assert!(events.is_empty());
+    }
+
+    #[tokio::test]
+    async fn run_drains_until_shutdown() {
+        use crate::bus::EventBus;
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("trace.jsonl");
+
+        let bus = EventBus::new();
+        let sender = bus.sender().unwrap();
+        let receiver = bus.subscribe();
+
+        let recorder = EventRecorder::create(&path).unwrap();
+        let handle = tokio::spawn(recorder.run(receiver));
+
+        sender
+            .send(make_event(EventCategory::Output(OutputEvent::Stdout {
+                content: "hello".to_string(),
+            })))
+            .unwrap();
+        sender
+            .send(make_event(EventCategory::System(SystemEvent::Shutdown)))
+            .unwrap();
+
+        handle.await.unwrap();
+
+        let events: Vec<CuenvEvent> = EventReplayReader::open(&path)
+            .unwrap()
+            .collect::<io::Result<Vec<_>>>()
+            .unwrap();
+        assert_eq!(events.len(), 2);
+        assert!(matches!(
+            events[1].category,
+            EventCategory::System(SystemEvent::Shutdown)
+        ));
+    }
+}


### PR DESCRIPTION
## Summary

Phase 3 of an 8-phase plan: land the conceptual `ActivityModel` / `UiState` boundary inside `TuiState`, plus a deterministic-replay invariant test that the same trace produces bit-identical model state every time.

Stacked on top of #389 (Phase 2), #388 (Phase 1), #387 (Phase 0). Commits unsigned (`--no-gpg-sign`) per explicit user authorization.

**Scope intentionally narrower than the original plan** — full field migration into separate structs touches every widget renderer (~70 references). This PR delivers the load-bearing piece (canonical `apply_event`, deterministic invariant, marker types + docs) so Phase 4 can build the group-aware spinner on top. Migrating renderers to take `(&ActivityModel, &UiState)` lands as a follow-up.

## What changed

- Marker types `ActivityModel` and `UiState` introduced in `state.rs` with module-level docs spelling out the boundary.
- `TuiState` fields grouped under section comments by concern (model fields first, UI fields second).
- `TuiState::apply_event(&CuenvEvent)` — single source of truth for every event-driven mutation. Funnels Started/CacheHit/Output/Completed/Skipped through one dispatcher; CacheMiss/CacheSkipped/Queued/Retrying/GroupStarted/GroupCompleted are reserved no-ops that Phase 4's spinner will pick up.
- `RichTui::handle_cuenv_event` now delegates the Task branch to `apply_event` and takes `&CuenvEvent`. Command-completion handling stays in RichTui because it owns the `can_quit`/`received_completion_event` flags.
- New integration test in `tests/tui_replay.rs`: `apply_event_is_deterministic_across_replays` replays the sample trace twice through fresh `TuiState`s and asserts task status, exit code, and output-line counts are identical.

## Test plan

- [x] `cargo test -p cuenv --test tui_replay` (6 integration tests pass, including the new determinism check)
- [x] `cargo test -p cuenv --lib tui` (24 unit tests pass)
- [x] `cargo clippy -p cuenv --all-targets -- -D warnings`
- [x] `cuenv fmt --fix`
- [ ] `nix flake check -L --accept-flake-config`

## Out of scope (deferred)

- Moving fields into `ActivityModel` / `UiState` structs and updating widget render signatures to take both refs separately. The boundary is documented + enforced via `apply_event`; physical field migration is a mechanical refactor that can land independently when widget signatures change for other reasons.

## Notes on CI

Phase 0 / 1 / 2 PRs (#387, #388, #389) hit the same Nix-daemon socket connection refused on the runners — environmental, not these PRs. Reruns have replayed the failure consistently. Flagging for awareness; not blocking on this PR's behalf.

The PR description is updated after every step is committed and pushed.