### PR TITLE
ci(sync-check): watch cuenv.lock for changes

### DIFF
--- a/.github/workflows/cuenv-sync-check.yml
+++ b/.github/workflows/cuenv-sync-check.yml
@@ -15,6 +15,8 @@ on:
     - CLAUDE.md/**
     - contrib/**
     - cue.mod/**
+    - cuenv.lock
+    - cuenv.lock/**
     - docs/design/specs/schema-coverage-matrix.md
     - docs/design/specs/schema-coverage-matrix.md/**
     - docs/src/content/docs/agents/**
@@ -41,6 +43,8 @@ on:
     - CLAUDE.md/**
     - contrib/**
     - cue.mod/**
+    - cuenv.lock
+    - cuenv.lock/**
     - docs/design/specs/schema-coverage-matrix.md
     - docs/design/specs/schema-coverage-matrix.md/**
     - docs/src/content/docs/agents/**

--- a/env.cue
+++ b/env.cue
@@ -190,7 +190,7 @@ schema.#Project & {
 			"sync-check": schema.#Task & {
 				command: "cuenv"
 				args: ["sync", "--check"]
-				inputs: ["env.cue", "schema/**", "contrib/**"]
+				inputs: ["env.cue", "schema/**", "contrib/**", "cuenv.lock"]
 			}
 
 			"schema-docs-check": schema.#Task & {


### PR DESCRIPTION
## Summary

- Add `cuenv.lock` to the `ci.sync-check` task's `inputs`, which extends the auto-derived GitHub workflow trigger paths to include the lockfile.
- Regenerate `.github/workflows/cuenv-sync-check.yml` via `cuenv sync ci`.

## Why

We hit this exact case earlier today: a lockfile-only commit (`ad13d17f chore: refresh cuenv lockfile`) intended to clear a sync-check failure didn't actually re-trigger sync-check, because `cuenv.lock` wasn't in the workflow's path filter. The CI status stayed red on the prior commit until something else in the watched set changed. Since `cuenv sync --check` is the task that fails on a stale lockfile in the first place, the lockfile belongs in its inputs.

## Test plan

- [ ] CI runs `cuenv-sync-check` on this PR (lockfile is unchanged here, so trigger is via `env.cue` change — still exercises the workflow end-to-end).
- [ ] Verify the regenerated workflow file matches expectations (`cuenv.lock` appears in `paths:` for both `push` and `pull_request`).
- [ ] Future lockfile-only commits will trigger sync-check.

This PR was created with the assistance of a LLM.