### PR TITLE
docs: rewrite README and docs landing for concrete, honest value

### DIFF
--- a/docs/src/content/docs/explanation/cuengine.md
+++ b/docs/src/content/docs/explanation/cuengine.md
@@ -7,7 +7,7 @@ The CUE Engine (`cuengine`) is a standalone Rust crate providing fast and reliab
 
 ## Overview
 
-The CUE Engine bridges the gap between Rust's performance and safety with CUE's powerful constraint-based configuration language. It provides a high-level API for evaluating CUE expressions, validating configurations, and extracting structured data.
+The CUE engine connects Rust to CUE's constraint-based configuration language. It provides a high-level API for evaluating CUE expressions, validating configurations, and extracting structured data for the rest of cuenv.
 
 ## Architecture
 
@@ -270,7 +270,7 @@ fn process_all_projects(module_root: &Path) -> cuengine::Result<Vec<Project>> {
 
 ## Testing
 
-The engine includes comprehensive test coverage:
+The engine is tested across:
 
 ```bash
 # Run all engine tests

--- a/docs/src/content/docs/explanation/cuenv-events.md
+++ b/docs/src/content/docs/explanation/cuenv-events.md
@@ -9,11 +9,11 @@ The `cuenv-events` crate provides a unified event system that enables multiple U
 
 When building tools with multiple output modes (CLI, JSON, TUI), you need a consistent way to emit and render events. This crate provides:
 
-- Typed event schema for task execution, CI, commands, and more
+- Typed event schema for task execution, CI, and command events
 - Direct `emit_*!` macros backed by a process-wide event sender
 - Broadcast-based event bus for multiple subscribers
 - Optional tracing layer integration for older event producers
-- CLI and JSON renderers out of the box
+- Built-in CLI and JSON renderers
 
 ## Architecture
 

--- a/docs/src/content/docs/explanation/dagger-backend.md
+++ b/docs/src/content/docs/explanation/dagger-backend.md
@@ -70,7 +70,7 @@ tasks: {
 
 ## Container Chaining
 
-Use the `from` field to continue from a previous task's container state. This is powerful for multi-stage builds where you install dependencies in one task and use them in subsequent tasks.
+Use the `from` field to continue from a previous task's container state. This suits multi-stage builds where you install dependencies in one task and use them in subsequent tasks.
 
 ```cue
 tasks: {

--- a/docs/src/content/docs/explanation/index.mdx
+++ b/docs/src/content/docs/explanation/index.mdx
@@ -14,8 +14,8 @@ Explanation is **understanding-oriented**. Read it when you want to know how cue
   <Card title="cuengine (CUE evaluation)" icon="right-arrow" href="/explanation/cuengine/">
     The Go↔Rust bridge and evaluation envelope.
   </Card>
-  <Card title="cuenv-cubes (Codegen)" icon="right-arrow" href="/explanation/cuenv-cubes/">
-    How the cube system generates and manages project files.
+  <Card title="Code generation" icon="right-arrow" href="/explanation/cuenv-codegen/">
+    How cuenv generates and syncs project files from CUE templates.
   </Card>
   <Card title="Decisions (ADRs & RFCs)" icon="right-arrow" href="/decisions/">
     Ratified decisions and proposals that shaped the system.

--- a/docs/src/content/docs/explanation/tools.md
+++ b/docs/src/content/docs/explanation/tools.md
@@ -345,7 +345,7 @@ The provider's cache key includes the profile, components, and targets to ensure
 ### Binary Verification
 
 1. **SHA256 hashing**: All downloaded binaries are verified against lockfile digests
-2. **Signature verification**: GitHub assets can leverage release signatures
+2. **Signature verification**: GitHub assets can use release signatures
 3. **Nix content-addressing**: Nix store paths are content-addressed
 
 ### Supply Chain

--- a/docs/src/content/docs/how-to/configure-a-project.md
+++ b/docs/src/content/docs/how-to/configure-a-project.md
@@ -46,7 +46,7 @@ schema.#Project & {
 
 // Environment variables
 env: {
-    NODE_ENV:  "development" | "production"
+    NODE_ENV:  "development" | "production" | *"development"
     PORT:      8080
     LOG_LEVEL: "info"
 }
@@ -74,19 +74,21 @@ tasks: {
 
 Define environment variables with type constraints:
 
+Every value needs a concrete result — a literal, or a constraint paired with a
+`*default` to fall back to.
+
 ```cue
 env: {
-    // String variables
-    NODE_ENV: "development" | "staging" | "production"
-    SERVICE_NAME: string & =~"^[a-zA-Z][a-zA-Z0-9-]*$"
+    // Enumerated values with a default.
+    NODE_ENV:     "development" | "staging" | "production" | *"development"
+    SERVICE_NAME: string & =~"^[a-zA-Z][a-zA-Z0-9-]*$" | *"my-service"
 
-    // Numeric variables (CUE treats environment variables as strings, so conversion might be needed or validation logic adjusted)
-    // Typically env vars are strings:
-    PORT: string & =~"^[0-9]+$"
+    // Environment variables are strings, so validate the string form.
+    PORT:         string & =~"^[0-9]+$" | *"8080"
     WORKER_COUNT: string | *"4"
 
-    // Boolean variables (as strings)
-    DEBUG: "true" | "false" | *"false"
+    // Booleans as strings.
+    DEBUG:          "true" | "false" | *"false"
     ENABLE_METRICS: "true" | "false" | *"true"
 }
 ```

--- a/docs/src/content/docs/how-to/configure-a-project.md
+++ b/docs/src/content/docs/how-to/configure-a-project.md
@@ -1,9 +1,9 @@
 ---
 title: Configuration
-description: Comprehensive guide to cuenv configuration
+description: Guide to configuring a cuenv project
 ---
 
-Learn how to configure cuenv for your projects using CUE's powerful constraint-based configuration language.
+Configure cuenv for your projects using CUE's constraint-based configuration language.
 
 ## Configuration Files
 
@@ -423,7 +423,7 @@ Extend validation with custom rules:
 ### Maintainability
 
 - Use schemas to enforce consistency
-- Leverage CUE's composition features
+- Use CUE's composition features
 - Keep environment differences minimal
 - Test configuration changes
 

--- a/docs/src/content/docs/how-to/contribute.md
+++ b/docs/src/content/docs/how-to/contribute.md
@@ -167,7 +167,7 @@ pub enum MyError {
 
 #### Testing
 
-Write comprehensive tests using Rust's built-in test framework:
+Write tests using Rust's built-in test framework:
 
 ```rust
 #[cfg(test)]

--- a/docs/src/content/docs/how-to/nix.md
+++ b/docs/src/content/docs/how-to/nix.md
@@ -211,7 +211,7 @@ schema.#Project & {
 // Environment variables (typed by CUE)
 env: {
     // App configuration
-    NODE_ENV: "development" | "production"
+    NODE_ENV: "development" | "production" | *"development"
     PORT:     3000
 
     // Database (Nix provides the postgres binary)

--- a/docs/src/content/docs/how-to/run-tasks.md
+++ b/docs/src/content/docs/how-to/run-tasks.md
@@ -3,7 +3,7 @@ title: Tasks
 description: Task orchestration and execution in cuenv
 ---
 
-cuenv provides a powerful task runner that leverages CUE for defining tasks, their dependencies, and their inputs/outputs. This enables parallel execution, caching, and hermetic builds.
+cuenv runs tasks defined in CUE. You declare each task's command, dependencies, and inputs/outputs; cuenv builds the dependency graph, runs independent tasks in parallel, caches results when you opt in, and isolates each task in its own working directory.
 
 ## Defining Tasks
 

--- a/docs/src/content/docs/how-to/troubleshooting.md
+++ b/docs/src/content/docs/how-to/troubleshooting.md
@@ -263,7 +263,7 @@ The command must be available in your PATH. Options:
 
 Large CUE configurations can be slow to evaluate. Tips:
 
-1. **Leverage the built-in task cache** by declaring accurate `inputs` and `outputs` for every task. Caching is automatic once those fields exist, and you can inspect the cache key for a task with:
+1. **Use the built-in task cache** by declaring accurate `inputs` and `outputs` and opting in with `cache.mode`. Once a task caches, you can inspect its cache key with:
 
    ```bash
    cuenv task build --show-cache-path

--- a/docs/src/content/docs/how-to/typed-environments.md
+++ b/docs/src/content/docs/how-to/typed-environments.md
@@ -11,23 +11,30 @@ Environments are defined in the `env` block of your `env.cue` file. You can use 
 
 ### Type Constraints
 
+Every `env` value must resolve to something concrete before cuenv runs — a
+literal value, or a constraint paired with a `*default` the value falls back to.
+A bare constraint like `PORT: string & =~"^[0-9]+$"` describes what's valid but
+has no value, so cuenv rejects it until you give it one.
+
 ```cue
 package cuenv
 
 env: {
-    // Basic types
-    HOST: string | *"0.0.0.0"
-    PORT: string & =~"^[0-9]+$"  // Regex validation
+    // A plain value.
+    HOST: "0.0.0.0"
 
-    // Enumerated values
-    NODE_ENV: "development" | "staging" | "production"
+    // Constrained, with a default the value falls back to.
+    PORT:      string & =~"^[0-9]+$" | *"3000"          // digits only, defaults to 3000
+    NODE_ENV:  "development" | "staging" | "production" | *"development"
     LOG_LEVEL: "trace" | "debug" | "info" | "warn" | "error" | *"info"
 
-    // Complex constraints
-    // Must be a valid URL
-    DATABASE_URL: string & =~"^postgres://"
+    // Must start with postgres://, defaults to a local database.
+    DATABASE_URL: string & =~"^postgres://" | *"postgres://localhost/app"
 }
 ```
+
+Set a value that breaks a constraint — say `NODE_ENV: "prod"` — and evaluation
+fails, pointing at the offending field, before any command runs.
 
 ## Environment Composition
 
@@ -38,12 +45,12 @@ You can organize your environment definitions into reusable schemas and compose 
 package shared
 
 #BaseEnv: {
-    LOG_LEVEL: "debug" | "info" | "warn" | "error"
+    LOG_LEVEL: "debug" | "info" | "warn" | "error" | *"info"
     REGION: string
 }
 
 #DatabaseEnv: {
-    DB_HOST: string
+    DB_HOST: string | *"localhost"
     DB_PORT: string | *"5432"
 }
 ```

--- a/docs/src/content/docs/how-to/typed-environments.md
+++ b/docs/src/content/docs/how-to/typed-environments.md
@@ -7,7 +7,7 @@ cuenv treats environment variables as a typed configuration schema rather than a
 
 ## Defining Environments
 
-Environments are defined in the `env` block of your `env.cue` file. You can use CUE's powerful type system to enforce constraints.
+Environments are defined in the `env` block of your `env.cue` file. You can use CUE's type system to enforce constraints.
 
 ### Type Constraints
 

--- a/docs/src/content/docs/how-to/vscode-extension.md
+++ b/docs/src/content/docs/how-to/vscode-extension.md
@@ -3,7 +3,7 @@ title: VSCode Extension
 description: Official VSCode integration for cuenv
 ---
 
-The official Cuenv VSCode extension brings powerful IDE integration for managing environments, running tasks, and visualizing dependencies directly from your editor.
+The official cuenv VSCode extension adds IDE integration for managing environments, running tasks, and visualizing dependencies from your editor.
 
 ## Installation
 

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -1,11 +1,11 @@
 ---
 title: cuenv
-description: Two commands. Type-safe environments. Secrets that never leak. Tasks that run in parallel.
+description: One typed config for your project — environment variables, secrets, tasks, and CI in CUE.
 template: splash
 hero:
   title: |
     <span class="text-gradient">cuenv</span>
-  tagline: Two commands. Type-safe environments. Secrets that never leak. Tasks that run in parallel.
+  tagline: One typed config for your whole project — environment variables, secrets, tasks, and CI in CUE.
   actions:
     - text: Start a tutorial
       link: /tutorials/first-project/
@@ -19,57 +19,19 @@ hero:
 
 import { Card, CardGrid } from '@astrojs/starlight/components';
 
-## The Problem
+## What is cuenv?
 
-You've been here before: secrets in `.env` files that get committed, "works on my machine" bugs, CI pipelines that can't run in parallel, and copy-paste task definitions with no validation.
+Most projects accumulate a pile of loosely related config: a `.env` file for
+variables, a `Makefile` or `justfile` for tasks, and a hand-written CI workflow
+that tries to stay in sync with both. Nothing validates any of it, secrets end
+up committed, and the three slowly drift apart.
 
-**cuenv fixes this with two primitives.**
+cuenv replaces that pile with a single `env.cue`. You describe your project once
+in [CUE](https://cuelang.org), a typed configuration language, and cuenv
+validates it, resolves secrets at runtime, runs your tasks, and generates your
+CI from the same definitions.
 
----
-
-## Two Primitives
-
-<CardGrid>
-  <Card title="cuenv exec -- <command>" icon="rocket">
-    Run any command with validated environment variables and secrets resolved at runtime. Never store credentials on disk.
-
-    ```bash
-    cuenv exec -- npm start
-    cuenv exec -e production -- ./deploy.sh
-    ```
-  </Card>
-  <Card title="cuenv task <name>" icon="list-format">
-    Run named tasks with automatic dependency resolution, parallel execution, and opt-in content-aware caching.
-
-    ```bash
-    cuenv task build
-    cuenv task -e staging deploy
-    ```
-  </Card>
-</CardGrid>
-
----
-
-## Why This Matters
-
-<CardGrid>
-  <Card title="Secrets Never Leak" icon="lock">
-    Secrets are fetched at runtime from 1Password or custom exec providers, never written to disk, never exported to your shell, and redacted from logs.
-  </Card>
-  <Card title="Validate Before You Run" icon="approve-check-circle">
-    CUE constraints catch `NODE_ENV: "prod"` typos before they become runtime failures. Type-safe configuration for your entire team.
-  </Card>
-  <Card title="Parallel by Default" icon="random">
-    Object keys run in parallel. Arrays run sequentially. Dependencies are respected. Your CI gets faster automatically.
-  </Card>
-  <Card title="Works Everywhere" icon="laptop">
-    Shell integration loads your environment when you `cd` into a project. Nix integration provisions tools automatically.
-  </Card>
-</CardGrid>
-
----
-
-## See It In Action
+## A complete example
 
 ```cue
 package cuenv
@@ -77,67 +39,104 @@ package cuenv
 import "github.com/cuenv/cuenv/schema"
 
 schema.#Project & {
-  name: "my-project"
+	name: "checkout-api"
 }
 
 env: {
-    NODE_ENV: "development" | "staging" | "production"
+	// Only these three values are accepted; anything else fails validation.
+	NODE_ENV: "development" | "staging" | "production"
 
-    // Secrets resolved at runtime, never stored
-    DB_PASSWORD: schema.#OnePasswordRef & {
-        ref: "op://vault/database/password"
-    }
+	HOST: "127.0.0.1"
+	PORT: "8080"
+	URL:  "http://\(HOST):\(PORT)"
+
+	// Resolved at runtime from 1Password. Never written to disk or your shell.
+	DATABASE_PASSWORD: schema.#OnePasswordRef & {
+		ref: "op://Engineering/checkout-db/password"
+	}
 }
 
 tasks: {
-    // These run in parallel
-    test: schema.#TaskGroup & {
-        type: "group"
-        unit:        schema.#Task & { command: "npm", args: ["run", "test:unit"] }
-        integration: schema.#Task & { command: "npm", args: ["run", "test:e2e"] }
-        lint:        schema.#Task & { command: "npm", args: ["run", "lint"] }
-    }
+	// The three children run in parallel.
+	check: schema.#TaskGroup & {
+		type: "group"
+		lint:  schema.#Task & {command: "npm", args: ["run", "lint"]}
+		types: schema.#Task & {command: "npm", args: ["run", "typecheck"]}
+		test:  schema.#Task & {command: "npm", args: ["test"]}
+	}
 
-    // This waits for test to complete
-    build: schema.#Task & {
-        command:   "npm"
-        args:      ["run", "build"]
-        dependsOn: [test]
-    }
+	// Waits for `check`; only re-runs when its inputs change.
+	build: schema.#Task & {
+		command:   "npm"
+		args:      ["run", "build"]
+		dependsOn: [check]
+		inputs:    ["src/**", "package.json"]
+		outputs:   ["dist/**"]
+		cache: mode: "read-write"
+	}
 }
 ```
 
----
+```bash
+cuenv task            # list what the project defines
+cuenv env print       # print the resolved environment (secrets redacted)
+cuenv task build      # run `check` in parallel, then `build`
+cuenv exec -- npm start   # run any command in the validated environment
+```
 
-## Status
+## Why CUE?
+
+A `.env` file is just strings, so nothing catches `NODE_ENV=prodction` until
+something breaks. CUE lets you describe the shape of valid config, and
+evaluation fails loudly when a value doesn't fit.
 
 <CardGrid>
-  <Card title="Core Engine" icon="approve-check-circle">
-    Complete. Fast CUE evaluation with Rust performance.
+  <Card title="Validate before you run" icon="approve-check-circle">
+    Enums, numeric bounds, regex patterns, and defaults are checked at
+    evaluation time. `NODE_ENV: "prod"` is caught before any command runs.
   </Card>
-  <Card title="CLI + Tasks" icon="approve-check-circle">
-    Stable. `exec`, `task`, and shell integration working.
+  <Card title="Secrets stay out of files" icon="lock">
+    Secrets resolve at runtime from your provider, never landing in `env.cue`,
+    generated files, or your shell, and are redacted from output.
   </Card>
-  <Card title="Secrets + Dagger" icon="warning">
-    Beta. Secret resolvers and Dagger backend available.
+  <Card title="Parallel by structure" icon="random">
+    Object keys in a task group run in parallel; arrays run in order;
+    `dependsOn` uses CUE references, so a typo is a compile error.
+  </Card>
+  <Card title="One source, no drift" icon="setting">
+    Environments, tasks, and CI come from the same file, so they can't fall out
+    of sync the way `.env` + `Makefile` + workflow YAML do.
   </Card>
 </CardGrid>
 
----
+## What works today
 
-## Get Started
+cuenv covers a lot, and not all of it is equally finished. The
+[schema status page](/reference/schema/status/) is the authoritative source for
+what's wired up.
+
+- **Solid:** typed environments, `cuenv exec`, tasks (groups, sequences,
+  dependencies, params, output refs, opt-in caching), shell integration and
+  hooks, and GitHub Actions generation via `cuenv sync ci`.
+- **Secrets:** environment variables, any CLI (`#ExecSecret`), 1Password, and
+  Infisical resolve today. AWS, GCP, and Vault are schema-only for now.
+- **In progress:** Buildkite/GitLab CI, multi-source tools, codegen,
+  `.rules.cue` generation, release management, services, and container/Dagger
+  runtimes.
+
+## Get started
 
 <CardGrid>
   <Card title="Tutorials" icon="right-arrow">
-    Learn cuenv by doing: start with [Your first cuenv project](/tutorials/first-project/).
+    Learn by doing: start with [Your first cuenv project](/tutorials/first-project/).
   </Card>
   <Card title="How-to guides" icon="right-arrow">
     Get something done: [install](/how-to/install/), [configure](/how-to/configure-a-project/), and [run tasks](/how-to/run-tasks/).
   </Card>
   <Card title="Reference" icon="right-arrow">
-    Look things up: [CLI](/reference/cli/), [CUE schema](/reference/cue-schema/), [Rust API](/reference/rust-api/).
+    Look things up: [CLI](/reference/cli/), [CUE schema](/reference/cue-schema/), [schema status](/reference/schema/status/).
   </Card>
   <Card title="GitHub" icon="github">
-    [Star us on GitHub](https://github.com/cuenv/cuenv) and contribute to the project.
+    [Browse the source](https://github.com/cuenv/cuenv) and join the discussion.
   </Card>
 </CardGrid>

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -43,8 +43,8 @@ schema.#Project & {
 }
 
 env: {
-	// Only these three values are accepted; anything else fails validation.
-	NODE_ENV: "development" | "staging" | "production"
+	// Only these three values are accepted; defaults to "development".
+	NODE_ENV: "development" | "staging" | "production" | *"development"
 
 	HOST: "127.0.0.1"
 	PORT: "8080"

--- a/docs/src/content/docs/reference/ci-contributors.md
+++ b/docs/src/content/docs/reference/ci-contributors.md
@@ -606,7 +606,7 @@ fn test_onepassword_contributor_active_with_op_refs() {
 
 To test your custom CUE contributors, create an example project and verify the generated IR or workflow files contain the expected tasks.
 
-See `crates/ci/tests/ir_contributor_tests.rs` for comprehensive test examples.
+See `crates/ci/tests/ir_contributor_tests.rs` for worked test examples.
 
 ## See Also
 

--- a/docs/src/content/docs/reference/index.mdx
+++ b/docs/src/content/docs/reference/index.mdx
@@ -20,7 +20,7 @@ Reference is **information-oriented**. It’s designed for scanning and lookup.
   <Card title="CI Contributors" icon="right-arrow" href="/reference/ci-contributors/">
     Stage contributors for CI pipeline setup tasks.
   </Card>
-  <Card title="Examples" icon="right-arrow" href="/reference/reference/examples/">
+  <Card title="Examples" icon="right-arrow" href="/reference/examples/">
     Complete configurations you can copy and adapt.
   </Card>
 </CardGrid>

--- a/docs/src/content/docs/tutorials/first-project.md
+++ b/docs/src/content/docs/tutorials/first-project.md
@@ -34,7 +34,7 @@ schema.#Project & {
 }
 
 env: {
-  NODE_ENV: "development" | "production"
+  NODE_ENV: "development" | "production" | *"development"
   PORT:     "3000"
 }
 

--- a/readme.md
+++ b/readme.md
@@ -49,8 +49,8 @@ schema.#Project & {
 }
 
 env: {
-	// Only these three values are accepted; anything else fails validation.
-	NODE_ENV: "development" | "staging" | "production"
+	// Only these three values are accepted; defaults to "development".
+	NODE_ENV: "development" | "staging" | "production" | *"development"
 
 	// Ordinary values, with CUE interpolation.
 	HOST: "127.0.0.1"
@@ -86,11 +86,20 @@ tasks: {
 
 List what the project defines:
 
-```bash
-cuenv task
+```console
+$ cuenv task
+Tasks from env.cue:
+├─ build [1]
+└─ check
+   ├─ check.lint
+   ├─ check.test
+   └─ check.types
+
+(5 tasks, 0 groups, 0 cached)
 ```
 
-Print the resolved environment — secret values are redacted, never printed:
+Print the resolved environment. Secrets are resolved from your provider at print
+time and shown redacted, never in the clear:
 
 ```bash
 cuenv env print
@@ -119,16 +128,17 @@ when a value doesn't fit.
 
 ```cue
 env: {
-	NODE_ENV: "development" | "staging" | "production" // an enum
-	PORT:     >0 & <65536                              // a bounded number
-	LOG_URL:  string & =~"^https://"                   // a pattern
-	TIMEOUT:  string | *"30s"                          // a default
+	NODE_ENV: "development" | "staging" | "production" | *"development" // an enum, default development
+	PORT:     >0 & <65536 | *3000                                       // a bounded number, default 3000
+	TIMEOUT:  string | *"30s"                                           // any string, default 30s
 }
 ```
 
-Set `NODE_ENV: "prod"` and cuenv refuses to run, pointing at the offending
-field. CUE also composes: you can `import` shared definitions and reuse them
-across services in a monorepo, instead of copy-pasting `.env` files.
+Each field declares what counts as valid and what it defaults to. Set
+`NODE_ENV: "prod"` and cuenv refuses to run, pointing at `env.NODE_ENV`. CUE also
+composes: you can `import` shared definitions and reuse them across services in
+a monorepo, instead of copy-pasting `.env` files. Patterns (`=~"^https://"`) and
+many other constraints work the same way.
 
 New to CUE? The [CUE site](https://cuelang.org) is the best starting point; you
 only need the basics to be productive with cuenv.

--- a/readme.md
+++ b/readme.md
@@ -1,577 +1,292 @@
 # cuenv
 
-**Two commands. Type-safe environments. Secrets that never leak. Tasks that run in parallel.**
+One typed config for your whole project. Define your environment variables,
+secrets, tasks, and CI in [CUE](https://cuelang.org); cuenv validates them,
+resolves secrets at runtime, runs your tasks, and generates your pipelines.
 
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL%20v3-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
 [![Build Status](https://github.com/cuenv/cuenv/actions/workflows/cuenv-ci.yml/badge.svg)](https://github.com/cuenv/cuenv/actions/workflows/cuenv-ci.yml)
 [![Crates.io](https://img.shields.io/crates/v/cuenv)](https://crates.io/crates/cuenv)
 
 > [!WARNING]
-> **Rapid iteration in progress.** I'm actively exploring the right APIs and schema to handle everything cuenv needs to do. Expect breaking changes between releases during this period. If you're using cuenv, be prepared for things to break.
+> **Rapid iteration in progress.** I'm actively exploring the right APIs and
+> schema to handle everything cuenv needs to do. Expect breaking changes between
+> releases during this period. If you're using cuenv, be prepared for things to
+> break.
 
----
+## What is cuenv?
 
-## The Problem
+Most projects accumulate a pile of loosely related config. A `.env` file (or an
+`.envrc`) for variables. A `Makefile` or `justfile` for tasks. A hand-written
+`.github/workflows/*.yml` that tries to stay in sync with both. Nothing
+validates any of it, secrets end up committed in `.env` files, and the three
+slowly drift apart.
 
-You've been here before:
+cuenv replaces that pile with a single `env.cue`. You describe your project once
+in CUE — a typed configuration language — and cuenv handles the rest:
 
-- **Secrets in `.env` files** that accidentally get committed, logged, or shared
-- **"Works on my machine"** because environment variables differ between developers
-- **Build scripts that can't run in parallel** so your CI takes forever
-- **Copy-paste task definitions** across projects with no validation
+- **Validates** every value against a schema before anything runs.
+- **Resolves secrets at runtime** from your provider, without writing them to disk.
+- **Runs your tasks** with dependency ordering, parallelism, and optional caching.
+- **Generates CI** workflows from the same task definitions.
 
-cuenv fixes this with two powerful primitives.
+It's written in Rust with a Go bridge to the CUE evaluator. The project moves
+fast (see the warning above), but the environment, task, and GitHub CI paths are
+in daily use.
 
----
+## A complete example
 
-## Two Primitives, Infinite Possibilities
-
-### `cuenv exec -- <command>`: Run Anything, Securely
-
-```bash
-cuenv exec -- npm start
-cuenv exec -e production -- ./deploy.sh
-cuenv exec -- cargo build --release
-```
-
-Every command runs with:
-
-- **Validated environment** - CUE constraints ensure `NODE_ENV` is actually `"development" | "staging" | "production"`, not a typo
-- **Secrets resolved at runtime** - Pulled from 1Password or custom exec providers, never stored in files or git history
-- **Environment-specific overrides** - Switch from dev to production with `-e production`
+Here is a small project — a typed environment with a runtime secret, plus a few
+tasks. Save it as `env.cue`:
 
 ```cue
-env: {
-    NODE_ENV: "development" | "staging" | "production"
-    PORT:     >0 & <65536 & *3000
-
-    // Secrets are resolved at runtime, redacted from logs
-    DB_PASSWORD: schema.#OnePasswordRef & {
-        ref: "op://vault/database/password"
-    }
-}
-```
-
-**Why this matters**: Your production credentials are never on disk. They're fetched when needed, used, and forgotten. `cuenv env print` shows `[SECRET]` instead of values. Shell exports exclude secrets entirely.
-
----
-
-### `cuenv task <name>`: Orchestrated, Parallel, Cached
-
-```bash
-cuenv task build
-cuenv task test
-cuenv task -e production deploy
-```
-
-Every task runs with:
-
-- **Automatic dependency resolution** - `build` waits for `lint` and `test` if configured
-- **Parallel execution** - Independent subtasks run simultaneously
-- **Opt-in content-aware caching** - Reuse task results when cache policy and inputs allow it
-- **Same secret + environment benefits** as `exec`
-
-```cue
-import "github.com/cuenv/cuenv/schema"
-
-tasks: {
-    // Parallel: unit, integration, and lint run at the same time
-    test: schema.#TaskGroup & {
-        type: "group"
-        unit:        schema.#Task & { command: "npm", args: ["run", "test:unit"] }
-        integration: schema.#Task & { command: "npm", args: ["run", "test:e2e"] }
-        lint:        schema.#Task & { command: "npm", args: ["run", "lint"] }
-    }
-
-    // Sequential: each step waits for the previous
-    deploy: schema.#TaskSequence & [
-        schema.#Task & { command: "docker", args: ["build", "-t", "myapp", "."] }
-        schema.#Task & { command: "docker", args: ["push", "myapp"] }
-        schema.#Task & { command: "kubectl", args: ["apply", "-f", "k8s/"] }
-    ]
-
-    // Dependencies: build won't start until test completes
-    // Note: dependsOn uses CUE references, not strings
-    build: schema.#Task & {
-        command:   "npm"
-        args:      ["run", "build"]
-        dependsOn: [test]  // CUE reference for compile-time validation
-        inputs:    ["src/**/*", "package.json"]
-        outputs:   ["dist/**/*"]
-    }
-}
-```
-
-**Why this matters**: Your test suite runs in parallel. Your CI is faster. Cacheable tasks can reuse results when inputs are unchanged. And every task inherits your validated environment and resolved secrets.
-
----
-
-## Quick Start
-
-```bash
-# Install cuenv
-nix profile install github:cuenv/cuenv
-# or: cargo install cuenv
-
-# Create configuration
-cat > env.cue << 'EOF'
 package cuenv
 
 import "github.com/cuenv/cuenv/schema"
 
 schema.#Project & {
-  name: "my-project"
+	name: "checkout-api"
 }
 
 env: {
-    NODE_ENV: "development" | "production"
-    API_KEY:  schema.#OnePasswordRef & { ref: "op://dev/api/key" }
+	// Only these three values are accepted; anything else fails validation.
+	NODE_ENV: "development" | "staging" | "production"
+
+	// Ordinary values, with CUE interpolation.
+	HOST: "127.0.0.1"
+	PORT: "8080"
+	URL:  "http://\(HOST):\(PORT)"
+
+	// Resolved at runtime from 1Password. Never written to disk or your shell.
+	DATABASE_PASSWORD: schema.#OnePasswordRef & {
+		ref: "op://Engineering/checkout-db/password"
+	}
 }
 
 tasks: {
-    dev:   schema.#Task & { command: "npm", args: ["run", "dev"] }
-    build: schema.#Task & { command: "npm", args: ["run", "build"] }
-    test:  schema.#Task & { command: "npm", args: ["test"] }
+	// The three children run in parallel.
+	check: schema.#TaskGroup & {
+		type: "group"
+		lint:  schema.#Task & {command: "npm", args: ["run", "lint"]}
+		types: schema.#Task & {command: "npm", args: ["run", "typecheck"]}
+		test:  schema.#Task & {command: "npm", args: ["test"]}
+	}
+
+	// Waits for `check`; only re-runs when its inputs change.
+	build: schema.#Task & {
+		command:   "npm"
+		args:      ["run", "build"]
+		dependsOn: [check]
+		inputs:    ["src/**", "package.json"]
+		outputs:   ["dist/**"]
+		cache: mode: "read-write"
+	}
 }
-EOF
+```
 
-# Run commands with your secure environment
-cuenv exec -- npm install
-cuenv task dev
+List what the project defines:
 
-# List available tasks
+```bash
 cuenv task
-
-# Generate CI workflows after adding ci.providers and ci.pipelines
-cuenv sync ci
 ```
 
----
-
-## Use Cases
-
-### Secure Your Secrets
-
-Stop committing `.env` files. Define secrets with any provider—they're resolved only when needed:
-
-```cue
-env: {
-    // 1Password
-    DB_PASSWORD: schema.#OnePasswordRef & { ref: "op://vault/db/password" }
-
-    // AWS Secrets Manager schema. Runtime resolver support is not registered by default.
-    API_KEY: schema.#AwsSecret & { secretId: "api-key" }
-
-    // HashiCorp Vault schema. Runtime resolver support is not registered by default.
-    STRIPE_KEY: schema.#VaultSecret & { path: "stripe", key: "key" }
-
-    // Or define your own resolver for any CLI
-    CUSTOM_SECRET: schema.#ExecSecret & {
-        command: "my-secret-tool"
-        args:    ["fetch", "my-secret"]
-    }
-}
-```
-
-Secrets are **never written to disk**, **never exported to your shell**, and **redacted from logs**.
-
----
-
-### Validate Before You Run
-
-Catch configuration errors before they become runtime failures:
-
-```cue
-env: {
-    // Constrained to valid values only
-    NODE_ENV: "development" | "staging" | "production"
-    LOG_LEVEL: "debug" | "info" | "warn" | "error"
-
-    // Must match patterns
-    DATABASE_URL: string & =~"^postgresql://"
-    API_ENDPOINT: string & =~"^https://"
-
-    // Numeric bounds
-    PORT: >0 & <65536
-
-    // Defaults that can be overridden
-    TIMEOUT: string | *"30s"
-}
-```
-
-If someone sets `NODE_ENV: "prod"` instead of `"production"`, cuenv tells them immediately.
-
----
-
-### Run Tasks in Parallel
-
-Object keys run in parallel. Arrays run sequentially. Dependencies are respected automatically:
-
-```cue
-import "github.com/cuenv/cuenv/schema"
-
-tasks: {
-    // These three run at the same time (parallel group)
-    lint: schema.#TaskGroup & {
-        type: "group"
-        check:  schema.#Task & { command: "eslint",   args: ["src/"] }
-        types:  schema.#Task & { command: "tsc",      args: ["--noEmit"] }
-        format: schema.#Task & { command: "prettier", args: ["--check", "."] }
-    }
-
-    // These run one after another (sequential)
-    deploy: schema.#TaskSequence & [
-        schema.#Task & { command: "npm",     args: ["run", "build"] }
-        schema.#Task & { command: "docker",  args: ["build", "-t", "app", "."] }
-        schema.#Task & { command: "docker",  args: ["push", "app"] }
-        schema.#Task & { command: "kubectl", args: ["rollout", "restart", "deployment/app"] }
-    ]
-
-    // This waits for lint to complete first (CUE reference)
-    build: schema.#Task & {
-        command:   "npm"
-        args:      ["run", "build"]
-        dependsOn: [lint]  // CUE reference, not string
-    }
-}
-```
-
----
-
-### Share Environments Across a Monorepo
-
-CUE configurations compose naturally. Define once, use everywhere:
-
-```
-myproject/
-├── env.cue              # Global settings
-├── shared/
-│   └── database.cue     # Shared DB config
-├── services/
-│   ├── api/
-│   │   └── env.cue      # Inherits global + adds API-specific
-│   └── web/
-│       └── env.cue      # Inherits global + adds web-specific
-```
-
-```cue
-// services/api/env.cue
-import "github.com/myorg/shared/database"
-
-env: database.#Config & {
-    SERVICE_NAME: "api"
-    PORT: 8080
-}
-```
-
----
-
-### Automatic Shell Integration
-
-When you `cd` into a cuenv project, your shell is configured automatically:
+Print the resolved environment — secret values are redacted, never printed:
 
 ```bash
-# Add to .zshrc / .bashrc
-eval "$(cuenv shell init zsh)"
-
-# Now just cd into your project
-cd ~/projects/myapp
-# → Environment loaded automatically
-# → Nix packages available (if configured)
-# → Ready to work
-```
-
----
-
-### CI Integration
-
-Generate CI workflows from your CUE configuration. Workflow generation requires
-explicit provider configuration:
-
-```cue
-import "github.com/cuenv/cuenv/schema"
-
-schema.#Project & {
-    name: "my-project"
-
-    let _t = tasks
-
-    ci: {
-        providers: ["github"]
-        pipelines: {
-            ci: {
-                when: {
-                    pullRequest: true
-                    branch:      "main"
-                }
-                tasks: [_t.test]
-            }
-        }
-    }
-
-    tasks: {
-        test: schema.#Task & {
-            command: "npm"
-            args: ["test"]
-            inputs: ["package.json", "src/**"]
-        }
-    }
-}
-```
-
-Then run:
-
-```bash
-# Generate configured GitHub Actions workflows
-cuenv sync ci
-
-# Run CI locally
-cuenv ci
-
-# Preview what would run
-cuenv ci --dry-run
-```
-
-GitHub workflow sync is the most complete provider path today. Check the schema
-status docs before relying on other provider surfaces.
-
----
-
-### Release Management
-
-Manage releases with changesets and automated publishing:
-
-```bash
-# Add a changeset describing your changes
-cuenv changeset add -s "Added dark mode" -P my-package:minor
-
-# Or generate from conventional commits
-cuenv changeset from-commits
-
-# Preview version bumps
-cuenv release version --dry-run
-
-# Publish packages in dependency order
-cuenv release publish
-```
-
-Changesets integrate with conventional commits and automatically calculate semantic version bumps.
-
----
-
-### Code Generation
-
-Generate and sync files from CUE templates—configuration files, boilerplate, and more:
-
-```bash
-# Sync all generated files
-cuenv sync codegen
-
-# Check if files are in sync (useful in CI)
-cuenv sync codegen --check
-
-# Preview changes
-cuenv sync codegen --diff --dry-run
-```
-
-Define codegen in your CUE configuration to generate TypeScript configs, Dockerfiles, or any templated content.
-
----
-
-### Multi-Platform VCS Support
-
-cuenv supports GitHub, GitLab, and Bitbucket for CODEOWNERS and CI integration:
-
-```bash
-# Sync generated rules for your platform
-cuenv sync
-
-# Works with GitHub, GitLab, or Bitbucket
-# Platform is auto-detected from your repository
-```
-
----
-
-## CLI Reference
-
-### Core Commands
-
-```bash
-# Execute commands with validated environment + resolved secrets
-cuenv exec -- npm start                    # or: cuenv x -- npm start
-cuenv exec -e production -- ./deploy.sh
-
-# Run named tasks with dependencies, parallelism, caching
-cuenv task build                           # or: cuenv t build
-cuenv task -e staging test
-cuenv task --tui build                     # Rich TUI output
-cuenv task -l ci                           # Run all tasks with label "ci"
-```
-
-### Environment Management
-
-```bash
-# View environment (secrets are redacted)
 cuenv env print
-cuenv env print --output json
-cuenv env list                             # List available environments
-
-# Shell integration
-cuenv shell init zsh >> ~/.zshrc
-cuenv env load                             # Load environment in background
-cuenv env status                           # Check hook execution status
 ```
 
-### Code Generation & Sync
+Run a task. `check` runs its three children in parallel; `build` waits for them
+to pass and is skipped on a cache hit when nothing changed:
 
 ```bash
-# Sync generated files from CUE configuration
-cuenv sync                                 # Sync all
-cuenv sync codegen                         # Sync code from CUE codegen
-cuenv sync ci                              # Sync CI workflows
-cuenv sync vcs                             # Sync VCS dependencies
-cuenv sync --check                         # Check if files are in sync
+cuenv task build
 ```
 
-### CI & Release Management
+Run any command inside the same validated environment:
 
 ```bash
-# CI integration
-cuenv ci                                   # Run CI pipeline
-cuenv sync ci                              # Generate configured CI workflows
-cuenv ci --dry-run                         # Preview what would run
-
-# Release management
-cuenv changeset add                        # Add a changeset entry
-cuenv changeset status                     # Show pending changesets
-cuenv changeset from-commits               # Generate from conventional commits
-cuenv release version                      # Calculate and apply version bumps
-cuenv release publish                      # Publish to crates.io
+cuenv exec -- npm start
+cuenv exec -e production -- ./deploy.sh
 ```
 
-### Security & Utilities
+## Why CUE?
+
+A `.env` file is just strings, so nothing catches `NODE_ENV=prodction` until
+something breaks at runtime. [CUE](https://cuelang.org) is a typed configuration
+language: you describe the *shape* of valid config, and evaluation fails loudly
+when a value doesn't fit.
+
+```cue
+env: {
+	NODE_ENV: "development" | "staging" | "production" // an enum
+	PORT:     >0 & <65536                              // a bounded number
+	LOG_URL:  string & =~"^https://"                   // a pattern
+	TIMEOUT:  string | *"30s"                          // a default
+}
+```
+
+Set `NODE_ENV: "prod"` and cuenv refuses to run, pointing at the offending
+field. CUE also composes: you can `import` shared definitions and reuse them
+across services in a monorepo, instead of copy-pasting `.env` files.
+
+New to CUE? The [CUE site](https://cuelang.org) is the best starting point; you
+only need the basics to be productive with cuenv.
+
+## What you can do today
+
+cuenv covers a lot of surface, and not all of it is equally finished. This is an
+honest map; the [schema status page](https://cuenv.dev/reference/schema/status/)
+is the authoritative source for what's wired up.
+
+**Typed environments.** Constrain values with enums, bounds, regexes, and
+defaults. Interpolate between variables. Define per-environment overrides and
+select them with `-e production`.
+
+**Runtime secrets.** Secrets are resolved when a command runs, kept out of
+`env.cue` and generated files, and redacted from output. Resolvers that work
+today: environment variables, any CLI via `#ExecSecret`, 1Password
+(`#OnePasswordRef`), and Infisical (`#InfisicalSecret`). `#AwsSecret`,
+`#GcpSecret`, and `#VaultSecret` exist in the schema but their runtime resolvers
+aren't registered yet — treat them as future work.
+
+**Tasks.** Object keys in a `#TaskGroup` run in parallel; arrays in a
+`#TaskSequence` run in order; `dependsOn` uses CUE references so a typo is a
+compile error, not a runtime surprise. Tasks support CLI parameters, output
+references between tasks, and opt-in content-addressed caching (`cache.mode`).
+`timeout`, `retry`, `continueOnError`, and group `maxConcurrency` are in the
+schema but not yet fully enforced.
+
+**Shell integration & hooks.** `cuenv shell init <shell>` loads a project's
+environment when you `cd` into it, direnv-style. Hooks run in the background
+behind an approval gate (`cuenv allow`) so a freshly cloned repo can't run code
+without your say-so.
+
+**CI generation.** `cuenv sync ci` turns your pipelines into GitHub Actions
+workflows, reusing the same task graph. GitHub is the solid path today;
+Buildkite export is partial, and GitLab is schema-only (sync rejects it until an
+emitter exists).
+
+**Also in progress.** Multi-source tool management (Nix, GitHub releases, OCI,
+URLs), code generation, `.gitignore`/`CODEOWNERS` generation from `.rules.cue`,
+release management with changesets, long-running services, and container/Dagger
+task runtimes. Check the schema status page before relying on any of these.
+
+## Install
 
 ```bash
-# Security approval for configurations
-cuenv allow                                # Approve configuration for hooks
-cuenv deny                                 # Revoke approval
+# Nix
+nix profile install github:cuenv/cuenv
 
-# Utilities
-cuenv version                              # Show version info
-cuenv completions zsh                      # Generate shell completions
+# Cargo
+cargo install cuenv
 ```
 
-### Global Options
+See [Install cuenv](https://cuenv.dev/how-to/install/) for other platforms,
+shell integration, and verification steps.
 
-| Option            | Description                                   |
-| ----------------- | --------------------------------------------- |
-| `--env, -e`       | Environment to use (dev, staging, production) |
-| `-p, --path`      | Directory with CUE files (default: ".")       |
-| `--package`       | CUE package name (default: "cuenv")           |
-| `--output`        | Command output format where supported         |
-| `-L, --level`     | Log level (trace, debug, info, warn, error)   |
+## CLI at a glance
 
----
+```bash
+cuenv exec -- <command>   # run a command in the validated environment (alias: x)
+cuenv task [name]         # list tasks, or run one (alias: t)
+cuenv env print           # show the resolved environment (secrets redacted)
+cuenv env list            # list available environments
+cuenv shell init <shell>  # print shell integration for bash/zsh/fish
+cuenv allow / deny        # approve or revoke hook execution for a directory
+cuenv sync ci             # generate CI workflows from your pipelines
+cuenv fmt                 # format CUE and other configured languages
+```
 
-## How It Compares
-
-| Feature                | cuenv              | Make       | Bazel          | Taskfile   | direnv           |
-| ---------------------- | ------------------ | ---------- | -------------- | ---------- | ---------------- |
-| Type Safety            | ✅ CUE constraints | ❌         | ✅ BUILD files | ❌         | ❌               |
-| Monorepo Support       | ✅ Native          | ⚠️ Basic   | ✅ Excellent   | ⚠️ Basic   | ⚠️ Per-directory |
-| Environment Management | ✅ Typed + Secrets | ❌         | ❌             | ❌         | ✅ Basic         |
-| Task Dependencies      | ✅ Smart           | ✅         | ✅ Advanced    | ✅ Basic   | ❌               |
-| Parallel Execution     | ✅                 | ⚠️ -j flag | ✅             | ⚠️ Limited | ❌               |
-| Caching                | ✅ Content-aware   | ❌         | ✅ Advanced    | ❌         | ❌               |
-| CI Integration         | ✅ Native          | ❌         | ⚠️ Rules       | ❌         | ❌               |
-| Security Isolation     | ✅ Via Dagger      | ❌         | ✅ Sandboxing  | ❌         | ❌               |
-| Shell Integration      | ✅                 | ❌         | ❌             | ❌         | ✅               |
-
----
+Common flags: `-e/--env <name>` selects an environment, `-p/--path <dir>` points
+at the directory holding your CUE files, and `-L/--level <level>` sets log
+verbosity. Full details live in the [CLI reference](https://cuenv.dev/reference/cli/).
 
 ## Status
 
-| Component             | Status         |
-| --------------------- | -------------- |
-| CUE Evaluation Engine | ✅ Complete    |
-| CLI + Task Runner     | ✅ Complete    |
-| Secret Management     | ✅ Complete    |
-| Shell Integration     | ✅ Complete    |
-| CI Integration        | 🚧 Development |
-| Release Management    | 🚧 Development |
-| Code Generation       | 🚧 Development |
-| Security Isolation    | ✅ Complete    |
+| Area                          | Where it stands                                                  |
+| ----------------------------- | ---------------------------------------------------------------- |
+| CUE evaluation engine         | Solid — fast evaluation through the Go bridge                    |
+| Environments & `exec`         | Solid                                                            |
+| Tasks (`task`)                | Solid for groups, sequences, deps, params, output refs, caching  |
+| Secrets                       | env / exec / 1Password / Infisical work; AWS, GCP, Vault are schema-only |
+| Shell integration & hooks     | Solid                                                            |
+| CI generation                 | GitHub works; Buildkite partial; GitLab schema-only              |
+| Tools, codegen, rules, release| In progress — see the schema status page                         |
+| Services, container/Dagger    | Partial — see the schema status page                             |
 
----
+## How it compares
+
+cuenv overlaps with several tools at once. Roughly:
+
+| Capability             | cuenv               | Make    | Taskfile | direnv  | dotenv |
+| ---------------------- | ------------------- | ------- | -------- | ------- | ------ |
+| Typed/validated config | yes (CUE)           | no      | no       | no      | no     |
+| Environment management | yes, typed          | no      | no       | yes     | yes    |
+| Runtime secrets        | yes                 | no      | no       | no      | no     |
+| Task dependencies      | yes                 | yes     | yes      | no      | no     |
+| Parallel execution     | yes, by default     | `-j`    | limited  | no      | no     |
+| Content-addressed cache| yes, opt-in         | no      | no       | no      | no     |
+| CI generation          | yes (GitHub today)  | no      | no       | no      | no     |
+| Shell integration      | yes                 | no      | no       | yes     | no     |
+
+The point isn't to win every row — it's that cuenv keeps environments, tasks,
+and CI in one validated source instead of three that drift.
 
 ## Contributing
 
-We welcome contributions! cuenv is licensed under AGPL-3.0, ensuring it remains open source.
-
-### Development Setup
+Contributions are welcome. cuenv is licensed under AGPL-3.0.
 
 ```bash
-# Clone the repository
-jj git clone https://github.com/cuenv/cuenv
+git clone https://github.com/cuenv/cuenv
 cd cuenv
 
-# Enter development environment
+# Enter the dev environment (or `direnv allow` if you use direnv)
 nix develop
-# or with direnv: direnv allow
 
-# Project automation (this repo)
+# Project automation lives in cuenv itself
 cuenv task fmt.check
 cuenv task lint
 cuenv task test.unit
 cuenv task build
 ```
 
-### Architecture Overview
+See [Develop cuenv](https://cuenv.dev/how-to/develop-cuenv/) and
+[Contribute](https://cuenv.dev/how-to/contribute/) for the full workflow.
+
+### Architecture
 
 ```
 cuenv/
 ├── crates/
-│   ├── cuengine/       # CUE evaluation engine (Go FFI bridge)
-│   ├── core/           # Shared types, task execution, caching
-│   ├── cuenv/          # CLI and TUI
-│   ├── events/         # Event system for UI frontends
-│   ├── workspaces/     # Monorepo and package manager detection
-│   ├── ci/             # CI pipeline integration
-│   ├── release/        # Version management and publishing
-│   ├── codegen/        # CUE-based code generation
-│   ├── ignore/         # Ignore file generation
-│   ├── codeowners/     # CODEOWNERS generation
-│   ├── github/         # GitHub provider
-│   ├── gitlab/         # GitLab provider
-│   ├── bitbucket/      # Bitbucket provider
-│   └── dagger/         # Dagger task execution backend
-├── schema/             # CUE schema definitions
-├── examples/          # CUE configuration examples
-└── docs/               # Documentation
+│   ├── cuengine/   # CUE evaluation engine (Go FFI bridge)
+│   ├── core/       # Shared types, task execution, caching
+│   ├── cuenv/      # CLI and TUI
+│   ├── events/     # Event system for UI frontends
+│   ├── workspaces/ # Monorepo and package-manager detection
+│   ├── ci/         # CI pipeline integration
+│   ├── release/    # Version management and publishing
+│   ├── codegen/    # CUE-based code generation
+│   ├── ignore/     # Ignore-file generation
+│   ├── codeowners/ # CODEOWNERS generation
+│   ├── github/     # GitHub provider
+│   ├── gitlab/     # GitLab provider
+│   ├── bitbucket/  # Bitbucket provider
+│   └── dagger/     # Dagger task execution backend
+├── schema/         # CUE schema definitions
+├── examples/       # Runnable CUE configurations
+└── docs/           # Documentation site (cuenv.dev)
 ```
-
-### Testing
-
-- Unit tests: `cuenv task test.unit`
-- BDD tests: `cuenv task test.bdd`
-- Coverage: `cuenv task coverage`
-
----
 
 ## License
 
-Licensed under the [GNU Affero General Public License v3.0](LICENSE).
+Licensed under the [GNU Affero General Public License v3.0](license.md).
 
-**Why AGPL?** We believe in keeping cuenv open source while building a sustainable business. The AGPL ensures that any modifications or hosted services using cuenv remain open source, benefiting the entire community.
-
----
+**Why AGPL?** It keeps cuenv open source while leaving room for a sustainable
+business: modifications and hosted services built on cuenv stay open source too.
 
 ## Links
 
-- **Documentation**: [cuenv.dev](https://cuenv.dev) 🚧
-- **CUE Language**: [cuelang.org](https://cuelang.org)
+- **Documentation**: [cuenv.dev](https://cuenv.dev)
+- **CUE language**: [cuelang.org](https://cuelang.org)
 - **Discussion**: [GitHub Discussions](https://github.com/cuenv/cuenv/discussions)
-
----
-
-_Built in 🏴 󠁧󠁢󠁳󠁣󠁴󠁿w for the open source community_


### PR DESCRIPTION
Rewrite readme.md and the docs landing page around the unified-config
story: one typed env.cue defines environment, secrets, tasks, and CI,
replacing the usual .env + Makefile + hand-written CI YAML. Drop the
marketing scaffolding ("Two Primitives, Infinite Possibilities", the
rule-of-three tagline, repeated "Why this matters") in favor of a single
runnable example and a "Why CUE?" section.

Make capability claims honest against the schema coverage matrix: only
env/exec/1Password/Infisical secret resolvers work today (AWS/GCP/Vault
are schema-only), GitHub CI sync is the solid path (Buildkite partial,
GitLab rejected), and Dagger/services are partial. This removes the old
"Complete" overclaims that the matrix contradicts.

Fix two broken doc links (reference examples, cuenv-codegen), strip
AI-smell filler ("powerful", "comprehensive", "leverage", "and more",
"out of the box") across the docs tree, and correct a caching accuracy
bug in troubleshooting (caching is opt-in via cache.mode, not automatic).

https://claude.ai/code/session_019X6LkJE3YBMKZ5PwdQPSi5