### PR TITLE
fix: populate CUE error source context for miette diagnostics

### DIFF
--- a/crates/cuenv/src/commands/module_utils.rs
+++ b/crates/cuenv/src/commands/module_utils.rs
@@ -84,6 +84,22 @@ fn non_empty<K, V>(map: HashMap<K, V>) -> Option<HashMap<K, V>> {
     (!map.is_empty()).then_some(map)
 }
 
+/// Compute the byte offset of the start of a 1-based line number in `src`.
+///
+/// Returns `None` if `line` is 0 or exceeds the number of lines in the source.
+fn byte_offset_of_line(src: &str, line: usize) -> Option<usize> {
+    if line == 0 {
+        return None;
+    }
+    if line == 1 {
+        return Some(0);
+    }
+    src.char_indices()
+        .filter(|&(_, c)| c == '\n')
+        .nth(line - 2)
+        .map(|(idx, _)| idx + 1)
+}
+
 /// Convert cuengine error to `cuenv_core` error.
 #[must_use]
 pub fn convert_engine_error(err: cuengine::CueEngineError) -> cuenv_core::Error {
@@ -95,11 +111,55 @@ pub fn convert_engine_error(err: cuengine::CueEngineError) -> cuenv_core::Error 
             cuenv_core::Error::ffi(function, message)
         }
         cuengine::CueEngineError::CueParse { path, message } => {
-            cuenv_core::Error::cue_parse(&path, message)
+            annotate_cue_parse_error(&path, message)
         }
         cuengine::CueEngineError::Validation { message } => cuenv_core::Error::validation(message),
         cuengine::CueEngineError::Cache { message } => cuenv_core::Error::configuration(message),
     }
+}
+
+/// Build a `CueParse` error, populating source context when possible.
+///
+/// Reads the file at `path`, parses the `LINE:COL` from the Go error message,
+/// and computes a `miette::SourceSpan` pointing at that line. Falls back to
+/// a plain error without source context if anything fails.
+fn annotate_cue_parse_error(path: &std::path::Path, message: String) -> cuenv_core::Error {
+    let Some(src) = std::fs::read_to_string(path).ok() else {
+        return cuenv_core::Error::cue_parse(path, message);
+    };
+
+    let Some((line, _col)) = parse_line_col_from_message(&message) else {
+        return cuenv_core::Error::cue_parse_with_source(path, message, src, None, None);
+    };
+
+    let span = byte_offset_of_line(&src, line).map(|offset| {
+        // Highlight the entire line (length = chars until newline or end).
+        let line_len = src[offset..].find('\n').unwrap_or(src.len() - offset);
+        miette::SourceSpan::from((offset, line_len))
+    });
+
+    cuenv_core::Error::cue_parse_with_source(path, message, src, span, None)
+}
+
+/// Extract the first `LINE:COL` pair from a CUE error message.
+///
+/// CUE errors from the Go bridge use the format:
+/// `./env.cue:LINE:COL: description` or `path/file.cue:LINE:COL: description`.
+///
+/// Iterates over `:` splits and returns the first pair of consecutive
+/// positive integers, skipping any leading path component.
+fn parse_line_col_from_message(message: &str) -> Option<(usize, usize)> {
+    let parts: Vec<&str> = message.split(':').collect();
+    for i in 0..parts.len().saturating_sub(1) {
+        let maybe_line = parts[i].trim().parse::<usize>();
+        let maybe_col = parts[i + 1].trim().parse::<usize>();
+        if let (Ok(line), Ok(col)) = (maybe_line, maybe_col)
+            && line > 0
+        {
+            return Some((line, col));
+        }
+    }
+    None
 }
 
 /// Compute the relative path from module root to target directory.


### PR DESCRIPTION
## Summary

- The `CueParse` error variant's `src` and `span` fields were always `None`, so miette's highlighted source snippet (the line with the arrow) never appeared when users had a syntax or type error in `env.cue`.
- In `convert_engine_error()` (`crates/cuenv/src/commands/module_utils.rs`), the `CueParse` arm now reads the source file, parses the `LINE:COL` from the Go bridge message, computes a `SourceSpan`, and calls `cue_parse_with_source()`.
- Failure is graceful at every step: unreadable files or unparseable positions fall back to the pre-existing plain-message behaviour — no crashes, no panics.

## What changes

Only `crates/cuenv/src/commands/module_utils.rs` is modified. Three private helpers are added:

- `byte_offset_of_line(src, line)` — computes byte offset of the start of a 1-based line.
- `parse_line_col_from_message(message)` — extracts the first `LINE:COL` pair from a CUE error string by scanning `:` splits.
- `annotate_cue_parse_error(path, message)` — orchestrates the read + parse + span construction, falls back at each failure point.

No changes to `cuengine`, `cuenv-core`, or any other crate.

## Test plan

- [ ] Introduce a deliberate syntax error in `examples/env-basic/env.cue` (e.g. `foo` on its own line) and run `cuenv exec -- cargo run -- env print --path examples/env-basic --package examples`. Verify the miette output now shows the highlighted source line with the label "parsing failed here".
- [ ] Remove the error and verify normal operation is unaffected.
- [ ] `cargo clippy -p cuenv --lib` — no warnings.
- [ ] `cargo check -p cuenv` — clean compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EKeswnu6BJrfQrWwaFSjZe