### PR TITLE
fix: release version command stale help text and error UX

### DIFF
--- a/crates/cuenv/src/cli/subcommands.rs
+++ b/crates/cuenv/src/cli/subcommands.rs
@@ -516,9 +516,7 @@ pub enum ReleaseCommands {
         no_pr: bool,
     },
     /// Calculate and apply version bumps from changesets.
-    #[command(
-        about = "Calculate and apply version bumps from changesets (manifest reading not yet implemented)"
-    )]
+    #[command(about = "Calculate and apply version bumps from changesets")]
     Version {
         /// Path to project root.
         #[arg(long, short = 'p', help = "Path to project root", default_value = ".")]

--- a/crates/cuenv/src/commands/release.rs
+++ b/crates/cuenv/src/commands/release.rs
@@ -454,8 +454,9 @@ pub fn execute_release_version(
         .map_err(|e| cuenv_core::Error::configuration(format!("Failed to read changesets: {e}")))?;
 
     if changesets.is_empty() {
-        return Err(cuenv_core::Error::configuration(
-            "No changesets found. Run 'cuenv changeset add' first.",
+        return Err(cuenv_core::Error::execution_with_help(
+            "No changesets found",
+            "Create a changeset first: cuenv changeset add",
         ));
     }
 

--- a/docs/src/content/docs/how-to/releases.md
+++ b/docs/src/content/docs/how-to/releases.md
@@ -372,9 +372,6 @@ do not present it as a finished pipeline.
 - **CUE registry publishing is not implemented.** If you configure a `cue`
   backend, `cuenv release publish` accepts it in `--dry-run` but **fails fast**
   with "CUE registry release publishing is not implemented yet" on a real run.
-- **`release version` help carries a caveat.** Its clap help notes that manifest
-  reading is "not yet implemented" in full; treat workspace-only manifests as
-  the supported shape and verify the rewritten files.
 - **Binary backend coverage is limited.** `release binaries` loads configured
   targets and backends from `env.cue`, but build-backend coverage is partial —
   validate artifacts before trusting a `--publish-only` run.

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -881,10 +881,6 @@ cuenv release version [OPTIONS]
 - `-p, --path <PATH>`: Path to project root. Default: `.`
 - `--dry-run`: Show what would change without making changes.
 
-:::caution[Manifest reading is incomplete]
-The clap help for `cuenv release version` flags manifest reading as not yet implemented. Prefer `cuenv release prepare` for the full analyze → bump → changelog → PR flow until manifest reading lands.
-:::
-
 #### `cuenv release publish`
 
 Publish packages in topological order.


### PR DESCRIPTION
## Summary

- Remove the `(manifest reading not yet implemented)` caveat from `cuenv release version`'s clap help and from both the how-to/releases and reference/cli docs — the command reads Cargo manifests and updates them correctly
- Replace the generic `configuration` error for missing changesets with `execution_with_help` that tells the user `"Create a changeset first: cuenv changeset add"`

## Test plan

- [ ] `cuenv release version --help` shows clean description with no stale caveat
- [ ] Running `cuenv release version` with no changesets shows actionable help hint
- [ ] Docs no longer reference the removed caveat