### PR TITLE
perf: improve graph and event hot paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1469,6 +1469,7 @@ name = "cuenv-events"
 version = "0.54.0"
 dependencies = [
  "chrono",
+ "criterion",
  "indicatif",
  "serde",
  "serde_json",

--- a/crates/core/src/tasks/cache.rs
+++ b/crates/core/src/tasks/cache.rs
@@ -151,6 +151,14 @@ pub async fn build_action(input: BuildActionInput<'_>) -> Result<CacheOutcome> {
         }
     }
 
+    if !task.env.is_empty() {
+        tracing::debug!(
+            task = %task_name,
+            "skipping cache: task defines task-level environment entries resolved at execution time"
+        );
+        return Ok(CacheOutcome::Skipped(CacheSkipReason::RuntimeEnv));
+    }
+
     let hashed = match resolve_hashed_inputs(cache, &patterns, project_root, task_name).await? {
         ResolveOutcome::Resolved(h) => h,
         ResolveOutcome::Skipped(reason) => return Ok(CacheOutcome::Skipped(reason)),
@@ -163,14 +171,6 @@ pub async fn build_action(input: BuildActionInput<'_>) -> Result<CacheOutcome> {
         return Ok(CacheOutcome::Skipped(CacheSkipReason::NoResolvedInputs));
     }
     let input_root_digest = build_input_root_digest(&hashed)?;
-
-    if !task.env.is_empty() {
-        tracing::debug!(
-            task = %task_name,
-            "skipping cache: task defines task-level environment entries resolved at execution time"
-        );
-        return Ok(CacheOutcome::Skipped(CacheSkipReason::RuntimeEnv));
-    }
 
     let mut environment_variables = BTreeMap::new();
     let resolved = environment.merge_with_system_hermetic();

--- a/crates/core/src/tasks/cache_tests.rs
+++ b/crates/core/src/tasks/cache_tests.rs
@@ -2,9 +2,22 @@ use super::*;
 use crate::environment::Environment;
 use crate::tasks::{Input, Task, TaskCacheMode, TaskCachePolicy};
 use cuenv_cas::{LocalActionCache, LocalCas};
-use cuenv_vcs::WalkHasher;
+use cuenv_vcs::{HashedInput, VcsHasher, WalkHasher};
 use std::fs;
 use tempfile::TempDir;
+
+struct PanicHasher;
+
+#[async_trait::async_trait]
+impl VcsHasher for PanicHasher {
+    async fn resolve_and_hash(&self, _patterns: &[String]) -> cuenv_vcs::Result<Vec<HashedInput>> {
+        panic!("runtime-env tasks should skip cache before hashing inputs");
+    }
+
+    fn name(&self) -> &'static str {
+        "panic"
+    }
+}
 
 fn make_cache(root: &Path) -> TaskCacheConfig {
     TaskCacheConfig {
@@ -164,6 +177,36 @@ async fn build_action_returns_none_when_task_has_task_level_env() {
 
     assert!(result.is_none());
     assert!(!side_effect.exists());
+}
+
+#[tokio::test]
+async fn build_action_skips_runtime_env_before_hashing_inputs() {
+    let tmp = TempDir::new().unwrap();
+    fs::write(tmp.path().join("input.txt"), "payload").unwrap();
+    let mut cache = make_cache(tmp.path());
+    cache.vcs_hasher = Arc::new(PanicHasher);
+
+    let mut task = make_task("echo", &["hi"], &["input.txt"], &[]);
+    task.env
+        .insert("TOKEN".to_string(), serde_json::json!("runtime"));
+    let env = Environment::new();
+
+    let outcome = build_action(BuildActionInput {
+        task: &task,
+        task_name: "task-env",
+        environment: &env,
+        cache: &cache,
+        workdir: tmp.path(),
+        project_root: tmp.path(),
+        module_root: tmp.path(),
+    })
+    .await
+    .unwrap();
+
+    assert!(matches!(
+        outcome,
+        CacheOutcome::Skipped(CacheSkipReason::RuntimeEnv)
+    ));
 }
 
 #[tokio::test]

--- a/crates/core/src/tasks/cache_tests.rs
+++ b/crates/core/src/tasks/cache_tests.rs
@@ -210,6 +210,36 @@ async fn build_action_skips_runtime_env_before_hashing_inputs() {
 }
 
 #[tokio::test]
+async fn build_action_runtime_env_skip_precedes_hasher_root_mismatch() {
+    let tmp = TempDir::new().unwrap();
+    fs::write(tmp.path().join("input.txt"), "payload").unwrap();
+    let mut cache = make_cache(tmp.path());
+    cache.vcs_hasher_root = tmp.path().join("other-root");
+
+    let mut task = make_task("echo", &["hi"], &["input.txt"], &[]);
+    task.env
+        .insert("TOKEN".to_string(), serde_json::json!("runtime"));
+    let env = Environment::new();
+
+    let outcome = build_action(BuildActionInput {
+        task: &task,
+        task_name: "task-env",
+        environment: &env,
+        cache: &cache,
+        workdir: tmp.path(),
+        project_root: tmp.path(),
+        module_root: tmp.path(),
+    })
+    .await
+    .unwrap();
+
+    assert!(matches!(
+        outcome,
+        CacheOutcome::Skipped(CacheSkipReason::RuntimeEnv)
+    ));
+}
+
+#[tokio::test]
 async fn build_action_hashes_inputs_relative_to_task_project_root() {
     let tmp = TempDir::new().unwrap();
     let workspace_root = tmp.path();

--- a/crates/events/Cargo.toml
+++ b/crates/events/Cargo.toml
@@ -42,8 +42,13 @@ thiserror = { workspace = true }
 indicatif = { workspace = true, optional = true }
 
 [dev-dependencies]
+criterion = { workspace = true }
 tokio = { workspace = true, features = ["full", "test-util"] }
 tempfile = { workspace = true }
+
+[[bench]]
+name = "json_renderer"
+harness = false
 
 [lints]
 workspace = true

--- a/crates/events/benches/json_renderer.rs
+++ b/crates/events/benches/json_renderer.rs
@@ -1,0 +1,57 @@
+//! Benchmarks for JSON event rendering.
+//!
+//! Run with: cargo bench -p cuenv-events --bench json_renderer
+
+use criterion::{Criterion, criterion_group, criterion_main};
+use cuenv_events::{CuenvEvent, EventCategory, EventSource, JsonRenderer, OutputEvent, TaskEvent};
+use std::hint::black_box;
+use uuid::Uuid;
+
+fn task_output_event(bytes: usize) -> CuenvEvent {
+    CuenvEvent::new(
+        Uuid::nil(),
+        EventSource::new("cuenv::task"),
+        EventCategory::Task(TaskEvent::Output {
+            name: "build".to_string(),
+            stream: cuenv_events::Stream::Stdout,
+            content: "x".repeat(bytes),
+            parent_group: None,
+        }),
+    )
+}
+
+fn output_event(bytes: usize) -> CuenvEvent {
+    CuenvEvent::new(
+        Uuid::nil(),
+        EventSource::new("cuenv::output"),
+        EventCategory::Output(OutputEvent::Stdout {
+            content: "x".repeat(bytes),
+        }),
+    )
+}
+
+fn benchmark_json_render_to_writer(c: &mut Criterion) {
+    let renderer = JsonRenderer::new();
+    let task_event = task_output_event(64 * 1024);
+    let generic_event = output_event(64 * 1024);
+
+    let mut group = c.benchmark_group("json_render_to_writer");
+    group.bench_function("task_output_64k", |b| {
+        let mut output = Vec::with_capacity(70 * 1024);
+        b.iter(|| {
+            output.clear();
+            black_box(renderer.render_to_writer(black_box(&task_event), &mut output))
+        });
+    });
+    group.bench_function("generic_output_64k", |b| {
+        let mut output = Vec::with_capacity(70 * 1024);
+        b.iter(|| {
+            output.clear();
+            black_box(renderer.render_to_writer(black_box(&generic_event), &mut output))
+        });
+    });
+    group.finish();
+}
+
+criterion_group!(benches, benchmark_json_render_to_writer);
+criterion_main!(benches);

--- a/crates/events/src/renderers/json.rs
+++ b/crates/events/src/renderers/json.rs
@@ -52,12 +52,12 @@ impl JsonRenderer {
     ///
     /// # Errors
     ///
-    /// Returns an error if writing to the target fails.
+    /// Returns an error if JSON serialization or writing to the target fails.
     pub fn render_to_writer(&self, event: &CuenvEvent, mut writer: impl Write) -> io::Result<()> {
         if self.pretty {
-            serde_json::to_writer_pretty(&mut writer, event).map_err(io::Error::other)?;
+            serde_json::to_writer_pretty(&mut writer, event).map_err(json_error_to_io)?;
         } else {
-            serde_json::to_writer(&mut writer, event).map_err(io::Error::other)?;
+            serde_json::to_writer(&mut writer, event).map_err(json_error_to_io)?;
         }
         writer.write_all(b"\n")
     }
@@ -73,11 +73,31 @@ impl JsonRenderer {
     }
 }
 
+fn json_error_to_io(error: serde_json::Error) -> io::Error {
+    if let Some(kind) = error.io_error_kind() {
+        io::Error::new(kind, error)
+    } else {
+        io::Error::other(error)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::event::{EventCategory, EventSource, OutputEvent};
     use uuid::Uuid;
+
+    struct BrokenPipeWriter;
+
+    impl std::io::Write for BrokenPipeWriter {
+        fn write(&mut self, _buf: &[u8]) -> io::Result<usize> {
+            Err(io::Error::new(io::ErrorKind::BrokenPipe, "writer failed"))
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
 
     fn create_test_event() -> CuenvEvent {
         CuenvEvent::new(
@@ -144,6 +164,18 @@ mod tests {
         assert!(output.ends_with(b"\n"));
         let json = std::str::from_utf8(&output).unwrap();
         assert!(json.contains("Test message"));
+    }
+
+    #[test]
+    fn test_render_to_writer_preserves_writer_error_kind() {
+        let renderer = JsonRenderer::new();
+        let event = create_test_event();
+
+        let error = renderer
+            .render_to_writer(&event, BrokenPipeWriter)
+            .expect_err("broken writer should fail");
+
+        assert_eq!(error.kind(), io::ErrorKind::BrokenPipe);
     }
 
     #[test]

--- a/crates/events/src/renderers/json.rs
+++ b/crates/events/src/renderers/json.rs
@@ -54,11 +54,12 @@ impl JsonRenderer {
     ///
     /// Returns an error if writing to the target fails.
     pub fn render_to_writer(&self, event: &CuenvEvent, mut writer: impl Write) -> io::Result<()> {
-        let Some(json) = self.render_to_string(event) else {
-            return Ok(());
-        };
-
-        writeln!(writer, "{json}")
+        if self.pretty {
+            serde_json::to_writer_pretty(&mut writer, event).map_err(io::Error::other)?;
+        } else {
+            serde_json::to_writer(&mut writer, event).map_err(io::Error::other)?;
+        }
+        writer.write_all(b"\n")
     }
 
     /// Render a single event to a string (for testing).

--- a/crates/task-graph/benches/graph_benchmarks.rs
+++ b/crates/task-graph/benches/graph_benchmarks.rs
@@ -10,6 +10,7 @@ use std::hint::black_box;
 #[derive(Debug, Clone)]
 struct BenchTask {
     deps: Vec<String>,
+    affected: bool,
 }
 
 impl TaskNodeData for BenchTask {
@@ -23,13 +24,17 @@ fn generate_wide_graph(task_count: usize) -> GraphResult<TaskGraph<BenchTask>> {
     let mut graph = TaskGraph::new();
 
     // Add root task
-    let root = BenchTask { deps: vec![] };
+    let root = BenchTask {
+        deps: vec![],
+        affected: false,
+    };
     graph.add_task("root", root)?;
 
     // Add many tasks that depend on root
     for i in 0..task_count {
         let task = BenchTask {
             deps: vec!["root".to_string()],
+            affected: false,
         };
         graph.add_task(&format!("task_{i}"), task)?;
     }
@@ -45,13 +50,17 @@ fn generate_deep_graph(depth: usize) -> GraphResult<TaskGraph<BenchTask>> {
     let mut graph = TaskGraph::new();
 
     // Add first task with no deps
-    let first = BenchTask { deps: vec![] };
+    let first = BenchTask {
+        deps: vec![],
+        affected: false,
+    };
     graph.add_task("task_0", first)?;
 
     // Add chain of tasks, each depending on the previous
     for i in 1..depth {
         let task = BenchTask {
             deps: vec![format!("task_{}", i - 1)],
+            affected: false,
         };
         graph.add_task(&format!("task_{i}"), task)?;
     }
@@ -67,7 +76,10 @@ fn generate_diamond_graph(width: usize, depth: usize) -> GraphResult<TaskGraph<B
     let mut graph = TaskGraph::new();
 
     // Root task
-    let root = BenchTask { deps: vec![] };
+    let root = BenchTask {
+        deps: vec![],
+        affected: false,
+    };
     graph.add_task("root", root)?;
 
     // Fan out: many tasks depend on root
@@ -80,6 +92,7 @@ fn generate_diamond_graph(width: usize, depth: usize) -> GraphResult<TaskGraph<B
             let task_name = format!("level_{level}_task_{w}");
             let task = BenchTask {
                 deps: prev_level.clone(),
+                affected: false,
             };
             graph.add_task(&task_name, task)?;
             current_level.push(task_name);
@@ -89,13 +102,52 @@ fn generate_diamond_graph(width: usize, depth: usize) -> GraphResult<TaskGraph<B
     }
 
     // Final task depends on all leaf tasks
-    let final_task = BenchTask { deps: prev_level };
+    let final_task = BenchTask {
+        deps: prev_level,
+        affected: false,
+    };
     graph.add_task("final", final_task)?;
 
     // Wire dependencies
     graph.add_dependency_edges()?;
 
     Ok(graph)
+}
+
+/// Generate a deep pipeline where the first task is directly affected and every
+/// later task depends on the previous task.
+fn generate_affected_chain(task_count: usize) -> GraphResult<(TaskGraph<BenchTask>, Vec<String>)> {
+    let mut graph = TaskGraph::new();
+    let mut pipeline_tasks = Vec::with_capacity(task_count);
+
+    for i in 0..task_count {
+        let name = format!("task_{i}");
+        let deps = if i == 0 {
+            Vec::new()
+        } else {
+            vec![format!("task_{}", i - 1)]
+        };
+        let task = BenchTask {
+            deps,
+            affected: i == 0,
+        };
+        graph.add_task(&name, task)?;
+        pipeline_tasks.push(name);
+    }
+
+    graph.add_dependency_edges()?;
+
+    Ok((graph, pipeline_tasks))
+}
+
+/// Generate the same dependency chain as [`generate_affected_chain`], but with
+/// pipeline order reversed to exercise order-independent propagation cost.
+fn generate_reverse_affected_chain(
+    task_count: usize,
+) -> GraphResult<(TaskGraph<BenchTask>, Vec<String>)> {
+    let (graph, mut pipeline_tasks) = generate_affected_chain(task_count)?;
+    pipeline_tasks.reverse();
+    Ok((graph, pipeline_tasks))
 }
 
 fn benchmark_get_parallel_groups(c: &mut Criterion) {
@@ -182,6 +234,48 @@ fn benchmark_graph_construction(c: &mut Criterion) {
     group.finish();
 }
 
+fn benchmark_compute_affected(c: &mut Criterion) {
+    let mut group = c.benchmark_group("compute_affected_ordered_deep_chain");
+
+    for count in [100, 500, 1000, 2000] {
+        let fixture = generate_affected_chain(count);
+        group.bench_with_input(
+            BenchmarkId::from_parameter(count),
+            &fixture,
+            |b, fixture| {
+                b.iter(|| {
+                    black_box(fixture.as_ref().map(|(graph, pipeline_tasks)| {
+                        graph.compute_affected(pipeline_tasks, |task| task.affected, None)
+                    }))
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+fn benchmark_compute_affected_reverse(c: &mut Criterion) {
+    let mut group = c.benchmark_group("compute_affected_reverse_deep_chain");
+
+    for count in [100, 500, 1000, 2000] {
+        let fixture = generate_reverse_affected_chain(count);
+        group.bench_with_input(
+            BenchmarkId::from_parameter(count),
+            &fixture,
+            |b, fixture| {
+                b.iter(|| {
+                    black_box(fixture.as_ref().map(|(graph, pipeline_tasks)| {
+                        graph.compute_affected(pipeline_tasks, |task| task.affected, None)
+                    }))
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
 criterion_group!(
     benches,
     benchmark_get_parallel_groups,
@@ -189,6 +283,8 @@ criterion_group!(
     benchmark_diamond_graph,
     benchmark_cycle_detection,
     benchmark_graph_construction,
+    benchmark_compute_affected,
+    benchmark_compute_affected_reverse,
 );
 
 criterion_main!(benches);

--- a/crates/task-graph/src/graph.rs
+++ b/crates/task-graph/src/graph.rs
@@ -4,6 +4,7 @@
 //! to handle dependencies and determine execution order.
 
 use crate::{Error, Result, TaskNodeData};
+use petgraph::Direction::Incoming;
 use petgraph::algo::{is_cyclic_directed, toposort};
 use petgraph::graph::{DiGraph, NodeIndex};
 use petgraph::visit::IntoNodeReferences;
@@ -232,27 +233,23 @@ impl<T: TaskNodeData> TaskGraph<T> {
         is_cyclic_directed(&self.graph)
     }
 
+    fn topological_indices(&self) -> Result<Vec<NodeIndex>> {
+        toposort(&self.graph, None).map_err(|_| Error::CycleDetected {
+            message: "Task dependency graph contains cycles".to_string(),
+        })
+    }
+
     /// Get topologically sorted list of tasks.
     ///
     /// # Errors
     ///
     /// Returns an error if the graph contains cycles.
     pub fn topological_sort(&self) -> Result<Vec<GraphNode<T>>> {
-        if self.has_cycles() {
-            return Err(Error::CycleDetected {
-                message: "Task dependency graph contains cycles".to_string(),
-            });
-        }
-
-        match toposort(&self.graph, None) {
-            Ok(sorted_indices) => Ok(sorted_indices
-                .into_iter()
-                .map(|idx| self.graph[idx].clone())
-                .collect()),
-            Err(_) => Err(Error::TopologicalSortFailed {
-                reason: "petgraph toposort failed".to_string(),
-            }),
-        }
+        let sorted_indices = self.topological_indices()?;
+        Ok(sorted_indices
+            .into_iter()
+            .map(|idx| self.graph[idx].clone())
+            .collect())
     }
 
     /// Get all tasks that can run in parallel (no dependencies between them).
@@ -264,31 +261,29 @@ impl<T: TaskNodeData> TaskGraph<T> {
     ///
     /// Returns an error if the graph contains cycles.
     pub fn get_parallel_groups(&self) -> Result<Vec<Vec<GraphNode<T>>>> {
-        let sorted = self.topological_sort()?;
+        let sorted = self.topological_indices()?;
 
         if sorted.is_empty() {
             return Ok(vec![]);
         }
 
-        // Group tasks by their dependency level
-        let mut groups: Vec<Vec<GraphNode<T>>> = vec![];
-        let mut processed: HashMap<String, usize> = HashMap::new();
+        let mut groups: Vec<Vec<GraphNode<T>>> = Vec::new();
+        let mut levels: HashMap<NodeIndex, usize> = HashMap::with_capacity(self.graph.node_count());
 
-        for task in sorted {
-            // Find the maximum level of all dependencies
-            let mut level = 0;
-            for dep in task.task.dependency_names() {
-                if let Some(&dep_level) = processed.get(dep) {
-                    level = level.max(dep_level + 1);
-                }
-            }
+        for node_index in sorted {
+            let level = self
+                .graph
+                .neighbors_directed(node_index, Incoming)
+                .filter_map(|dependency_index| levels.get(&dependency_index).copied())
+                .map(|dependency_level| dependency_level + 1)
+                .max()
+                .unwrap_or(0);
 
-            // Add to appropriate group
             if level >= groups.len() {
                 groups.resize(level + 1, vec![]);
             }
-            groups[level].push(task.clone());
-            processed.insert(task.name.clone(), level);
+            groups[level].push(self.graph[node_index].clone());
+            levels.insert(node_index, level);
         }
 
         Ok(groups)

--- a/crates/task-graph/src/graph/analysis.rs
+++ b/crates/task-graph/src/graph/analysis.rs
@@ -1,6 +1,7 @@
 use super::TaskGraph;
 use crate::TaskNodeData;
-use std::collections::HashSet;
+use petgraph::Direction::Outgoing;
+use std::collections::{HashSet, VecDeque};
 
 /// Borrowed predicate used to resolve whether an external dependency is affected.
 pub type ExternalAffectedResolver<'a> = &'a dyn Fn(&str) -> bool;
@@ -49,87 +50,48 @@ impl<T: TaskNodeData> TaskGraph<T> {
     where
         F: Fn(&T) -> bool,
     {
+        let pipeline_names: Vec<&str> = pipeline_tasks.iter().map(AsRef::as_ref).collect();
+        let pipeline_set: HashSet<&str> = pipeline_names.iter().copied().collect();
         let mut affected = HashSet::new();
+        let mut queue = VecDeque::new();
 
-        self.mark_directly_affected(pipeline_tasks, &is_directly_affected, &mut affected);
-        self.propagate_affected(pipeline_tasks, is_external_affected, &mut affected);
-        affected_in_pipeline_order(pipeline_tasks, &affected)
-    }
-
-    fn mark_directly_affected<F>(
-        &self,
-        pipeline_tasks: &[impl AsRef<str>],
-        is_directly_affected: &F,
-        affected: &mut HashSet<String>,
-    ) where
-        F: Fn(&T) -> bool,
-    {
-        for task_name in pipeline_tasks {
-            let task_name = task_name.as_ref();
-            if let Some(node) = self.get_node_by_name(task_name)
-                && is_directly_affected(&node.task)
+        for task_name in &pipeline_names {
+            let Some(&node_index) = self.name_to_node.get(*task_name) else {
+                continue;
+            };
+            let node = &self.graph[node_index];
+            if (is_directly_affected(&node.task)
+                || Self::has_affected_external_dependency(&node.task, is_external_affected))
+                && affected.insert((*task_name).to_string())
             {
-                affected.insert(task_name.to_string());
+                queue.push_back(node_index);
             }
         }
-    }
 
-    fn propagate_affected(
-        &self,
-        pipeline_tasks: &[impl AsRef<str>],
-        is_external_affected: Option<ExternalAffectedResolver<'_>>,
-        affected: &mut HashSet<String>,
-    ) {
-        let mut changed = true;
-        while changed {
-            changed = false;
-            for task_name in pipeline_tasks {
-                changed |= self.propagate_task_affected(
-                    task_name.as_ref(),
-                    is_external_affected,
-                    affected,
-                );
+        while let Some(node_index) = queue.pop_front() {
+            for dependent_index in self.graph.neighbors_directed(node_index, Outgoing) {
+                let dependent_name = self.graph[dependent_index].name.as_str();
+                if !pipeline_set.contains(dependent_name) || affected.contains(dependent_name) {
+                    continue;
+                }
+                affected.insert(dependent_name.to_string());
+                queue.push_back(dependent_index);
             }
         }
+
+        affected_in_pipeline_order(&pipeline_names, &affected)
     }
 
-    fn propagate_task_affected(
-        &self,
-        task_name: &str,
+    fn has_affected_external_dependency(
+        task: &T,
         is_external_affected: Option<ExternalAffectedResolver<'_>>,
-        affected: &mut HashSet<String>,
     ) -> bool {
-        if affected.contains(task_name) {
-            return false;
-        }
-
-        let Some(node) = self.get_node_by_name(task_name) else {
+        let Some(resolver) = is_external_affected else {
             return false;
         };
 
-        for dep in node.task.dependency_names() {
-            if self.dependency_is_affected(dep, is_external_affected, affected) {
-                affected.insert(task_name.to_string());
-                return true;
-            }
-        }
-
-        false
-    }
-
-    fn dependency_is_affected(
-        &self,
-        dep: &str,
-        is_external_affected: Option<ExternalAffectedResolver<'_>>,
-        affected: &HashSet<String>,
-    ) -> bool {
-        if dep.starts_with('#') {
-            return is_external_affected.is_some_and(|resolver| resolver(dep));
-        }
-
-        self.expand_dep_to_leaf_tasks(dep)
-            .into_iter()
-            .any(|leaf_dep| affected.contains(&leaf_dep))
+        task.dependency_names()
+            .any(|dep| dep.starts_with('#') && resolver(dep))
     }
 }
 
@@ -139,8 +101,10 @@ fn affected_in_pipeline_order(
 ) -> Vec<String> {
     pipeline_tasks
         .iter()
-        .map(|task| task.as_ref().to_string())
-        .filter(|task| affected.contains(task))
+        .filter_map(|task| {
+            let task = task.as_ref();
+            affected.contains(task).then(|| task.to_string())
+        })
         .collect()
 }
 

--- a/crates/task-graph/src/graph/graph_tests.rs
+++ b/crates/task-graph/src/graph/graph_tests.rs
@@ -603,6 +603,40 @@ fn test_compute_affected_transitive_only() {
 }
 
 #[test]
+fn test_compute_affected_reverse_pipeline_order() {
+    let mut graph = TaskGraph::new();
+    graph.add_task("build", TestTask::new(&[])).unwrap();
+    graph.add_task("test", TestTask::new(&["build"])).unwrap();
+    graph.add_task("deploy", TestTask::new(&["test"])).unwrap();
+    graph.add_dependency_edges().unwrap();
+
+    let affected = graph.compute_affected(
+        &["deploy", "test", "build"],
+        |task| task.depends_on.is_empty(),
+        None,
+    );
+
+    assert_eq!(affected, vec!["deploy", "test", "build"]);
+}
+
+#[test]
+fn test_compute_affected_does_not_propagate_through_non_pipeline_tasks() {
+    let mut graph = TaskGraph::new();
+    graph.add_task("build", TestTask::new(&[])).unwrap();
+    graph.add_task("test", TestTask::new(&["build"])).unwrap();
+    graph.add_task("deploy", TestTask::new(&["test"])).unwrap();
+    graph.add_dependency_edges().unwrap();
+
+    let affected = graph.compute_affected(
+        &["build", "deploy"],
+        |task| task.depends_on.is_empty(),
+        None,
+    );
+
+    assert_eq!(affected, vec!["build"]);
+}
+
+#[test]
 fn test_compute_affected_with_external_resolver() {
     let mut graph = TaskGraph::new();
     // build depends on an external project task, test depends on build

--- a/docs/src/content/docs/how-to/contribute.md
+++ b/docs/src/content/docs/how-to/contribute.md
@@ -9,7 +9,7 @@ We welcome contributions to cuenv! This guide will help you get started with con
 
 ### Prerequisites
 
-- Rust 1.70+ (install via [rustup](https://rustup.rs/))
+- Rust 1.85.0+ (install via [rustup](https://rustup.rs/))
 - Git for version control
 - Nix (optional, for reproducible development environment)
 - Go 1.21+ (for CUE engine development)
@@ -65,7 +65,8 @@ git checkout -b feature/my-new-feature
 4. **Test Your Changes**
 
 ```bash
-# Run the final review/merge/release gate, not the default per-commit check
+# Run the final review/merge/release gate, not the default per-commit check.
+# Release-only version bumps from an already-green main use the release-only checks below instead.
 nix flake check -L --accept-flake-config
 
 # Run specific crate tests
@@ -80,7 +81,7 @@ cuenv sync ci --check
 cuenv fmt --fix
 ```
 
-Use focused validation for isolated draft commits, then run the full Nix gate before requesting review or merging. Full flake checks are review/merge/release evidence and broad-risk safety nets, not the default proof for every draft commit. If the change does not match a required full-flake trigger below, do not run the full root flake check before a draft commit; commit and push the isolated draft change with the focused validation recorded in the PR.
+Use focused validation for isolated draft commits, then run the full Nix gate before requesting review or merging. Full flake checks are review/merge/release evidence and broad-risk safety nets, not the default proof for every draft commit. Release-only version bumps from an already-green `main` are the release exception: skip local test execution and the full root flake check, then verify version and lockfile consistency before tagging or publishing. If the change does not match a required full-flake trigger below, do not run the full root flake check before a draft commit; commit and push the isolated draft change with the focused validation recorded in the PR.
 
 Before starting a full root flake check, identify the trigger that requires it. If no trigger applies, keep validation focused and record the focused gate instead.
 
@@ -94,7 +95,7 @@ Start with focused validation when the change is isolated and the focused gate d
 
 Do not run the full root flake check for exploratory review work, docs-only edits, prompt or agent-guidance text including `AGENTS.md`, repo-local skill-only edits, simple mechanical test extraction commits, test moves, behavior-preserving module splits, one-crate test-only dev-dependency changes, or tiny scoped commits while the PR is still draft and focused checks cover the touched surface.
 
-Full root flake check is required before marking a PR ready for review, merging, release work, Nix/flake output/build/check wiring changes, CI/release behavior changes, generated workflow contract changes, broad cross-crate runtime changes, schema or CLI support changes that focused checks cannot fully cover, or Cargo manifest/lockfile changes that affect production dependencies, crate features, workspace membership, MSRV, published package metadata, or more than one crate.
+Full root flake check is required before marking a PR ready for review, merging, release work that is not a release-only version bump from an already-green `main`, Nix/flake output/build/check wiring changes, CI/release behavior changes, generated workflow contract changes, broad cross-crate runtime changes, schema or CLI support changes that focused checks cannot fully cover, or Cargo manifest/lockfile changes that affect production dependencies, crate features, workspace membership, MSRV, published package metadata, or more than one crate.
 
 If a change does not match one of those full-flake triggers, keep the check focused and record the focused validation in the PR.
 

--- a/docs/src/content/docs/how-to/contribute.md
+++ b/docs/src/content/docs/how-to/contribute.md
@@ -98,6 +98,17 @@ Full root flake check is required before marking a PR ready for review, merging,
 
 If a change does not match one of those full-flake triggers, keep the check focused and record the focused validation in the PR.
 
+For performance changes, make the claim measurable. Add or update Criterion
+coverage next to the hot path, keep a behavior regression test for the
+optimized code path, and run the narrow benchmark slice before and after the
+change. For example, task graph work can use
+`cargo bench -p cuenv-task-graph --bench graph_benchmarks -- <group>` and event
+rendering work can use
+`cargo bench -p cuenv-events --bench json_renderer -- <group>`. Treat the
+benchmark output as draft evidence; the full Nix gate is still only required
+when one of the full-flake triggers applies or the PR is being readied for
+review.
+
 5. **Commit and Push**
 
 ```bash

--- a/docs/src/content/docs/how-to/develop-cuenv.md
+++ b/docs/src/content/docs/how-to/develop-cuenv.md
@@ -7,7 +7,7 @@ This guide covers the development workflow for contributing to cuenv itself.
 
 ## Prerequisites
 
-- **Rust** 1.70+ via [rustup](https://rustup.rs/)
+- **Rust** 1.85.0+ via [rustup](https://rustup.rs/)
 - **Go** 1.21+ for the CUE evaluation bridge
 - **Nix** (recommended) for reproducible development environment
 - **Git** for version control


### PR DESCRIPTION
## Summary

This PR makes three scoped performance improvements with focused regression and benchmark coverage:

- replaces affected-task fixed-point scans with queue-based propagation over task graph edges
- computes task graph parallel groups from topological node indices instead of cloned nodes/string dependency lookups
- streams JSON events directly to writers instead of allocating an intermediate JSON string
- skips task cache input hashing for tasks that are already ineligible because they define task-level runtime env

It also adds Criterion coverage for affected-task propagation and JSON rendering, plus a contributor-doc note that performance changes should carry before/after benchmark evidence.

## Measured impact

Task graph:

- `compute_affected_reverse_deep_chain/2000`: ~416 ms -> ~517 us
- `compute_affected_reverse_deep_chain/1000`: ~101 ms -> ~269 us
- `get_parallel_groups/500`: ~141 us -> ~56 us

JSON renderer:

- 64 KiB task output event: ~96.6 us -> ~17.0 us
- 64 KiB generic output event: ~96.9 us -> ~17.1 us

## Validation

- `cuenv fmt --fix`
- `cargo fmt --all --check`
- `git diff --check`
- `cargo test -p cuenv-task-graph`
- `cargo test -p cuenv-events renderers::json`
- `cargo test -p cuenv-core build_action_`
- `cargo clippy -p cuenv-task-graph --all-targets -- -D warnings`
- `cargo clippy -p cuenv-events --all-targets -- -D warnings`
- `cargo clippy -p cuenv-core --all-targets -- -D warnings`
- `cuenv task ci.schema-docs-check`
- `cargo bench -p cuenv-task-graph --bench graph_benchmarks -- compute_affected_reverse_deep_chain`
- `cargo bench -p cuenv-task-graph --bench graph_benchmarks -- get_parallel_groups/500`
- `cargo bench -p cuenv-events --bench json_renderer -- json_render_to_writer`

I did not run the full root `nix flake check`; this is isolated draft performance work with focused validation, not a ready-for-review gate.